### PR TITLE
feat: add standalone card-builder and code-explorer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# Mining Syndicate Platform
+
+## Self-Contained Tools
+
+This repository includes optional tools that run separately from the main application.
+
+- **Card Builder**: `npm run card-builder` starts a local drag-and-drop card editor at http://localhost:3100.
+- **Code Explorer**: `npm run code-explorer <target-directory>` indexes a directory and serves a visual explorer at http://localhost:3200.
+
+These tools are standalone and do not affect production or the main development server.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
-    "db:push": "drizzle-kit push"
+    "db:push": "drizzle-kit push",
+    "card-builder": "node packages/card-builder/dev.js",
+    "code-explorer": "node packages/code-explorer/dev.js"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/packages/card-builder/dev.js
+++ b/packages/card-builder/dev.js
@@ -1,0 +1,19 @@
+import { createServer } from 'vite';
+import react from '@vitejs/plugin-react';
+import { fileURLToPath } from 'url';
+import path from 'path';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+async function run() {
+  const server = await createServer({
+    root: __dirname,
+    plugins: [react()],
+    server: { port: 3100 },
+    appType: 'spa'
+  });
+  await server.listen();
+  console.log('Card builder running at http://localhost:3100');
+}
+
+run();

--- a/packages/card-builder/index.html
+++ b/packages/card-builder/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Card Builder</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/index.tsx"></script>
+  </body>
+</html>

--- a/packages/card-builder/src/index.tsx
+++ b/packages/card-builder/src/index.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { DndContext, useDraggable, useDroppable } from '@dnd-kit/core';
+
+const globalDataElements = [
+  { id: 'text', label: 'Text' },
+  { id: 'number', label: 'Number' }
+];
+
+const computableContracts = [
+  { id: 'sum', label: 'Sum' },
+  { id: 'average', label: 'Average' }
+];
+
+function DraggableItem({ id, label }: { id: string; label: string }) {
+  const { attributes, listeners, setNodeRef, transform } = useDraggable({ id });
+  const style = { transform: transform ? `translate3d(${transform.x}px, ${transform.y}px, 0)` : undefined };
+  return (
+    <div ref={setNodeRef} style={{ padding: 8, border: '1px solid #ccc', marginBottom: 4, cursor: 'grab', ...style }} {...listeners} {...attributes}>
+      {label}
+    </div>
+  );
+}
+
+function Canvas({ items }: { items: string[] }) {
+  const { isOver, setNodeRef } = useDroppable({ id: 'canvas' });
+  return (
+    <div ref={setNodeRef} style={{ flex: 1, padding: 16, border: '2px dashed #999', background: isOver ? '#f0f0f0' : '#fff' }}>
+      <h3>Preview</h3>
+      {items.map((id, idx) => (
+        <div key={idx} style={{ padding: 8, border: '1px solid #ddd', marginBottom: 4 }}>{id}</div>
+      ))}
+    </div>
+  );
+}
+
+function App() {
+  const [items, setItems] = React.useState<string[]>([]);
+  const handleDragEnd = (event: any) => {
+    if (event.over && event.over.id === 'canvas') {
+      setItems([...items, event.active.id]);
+    }
+  };
+  const exportConfig = () => {
+    const json = JSON.stringify(items, null, 2);
+    const blob = new Blob([json], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'card.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+  return (
+    <DndContext onDragEnd={handleDragEnd}>
+      <div style={{ display: 'flex', gap: 16 }}>
+        <div style={{ width: 200 }}>
+          <h3>Global Data</h3>
+          {globalDataElements.map((el) => (
+            <DraggableItem key={el.id} id={el.id} label={el.label} />
+          ))}
+          <h3>Contracts</h3>
+          {computableContracts.map((el) => (
+            <DraggableItem key={el.id} id={el.id} label={el.label} />
+          ))}
+          <button onClick={exportConfig} style={{ marginTop: 8 }}>Export JSON</button>
+        </div>
+        <Canvas items={items} />
+      </div>
+    </DndContext>
+  );
+}
+
+const root = createRoot(document.getElementById('root')!);
+root.render(<App />);

--- a/packages/code-explorer/dev.js
+++ b/packages/code-explorer/dev.js
@@ -1,0 +1,33 @@
+import { createServer } from 'vite';
+import react from '@vitejs/plugin-react';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { scan } from './scan.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const targetDir = process.argv[2] ? path.resolve(process.argv[2]) : process.cwd();
+const data = scan(targetDir);
+
+async function run() {
+  const server = await createServer({
+    root: __dirname,
+    plugins: [
+      react(),
+      {
+        name: 'api-data',
+        configureServer(server) {
+          server.middlewares.use('/api/data', (req, res) => {
+            res.setHeader('Content-Type', 'application/json');
+            res.end(JSON.stringify(data));
+          });
+        }
+      }
+    ],
+    server: { port: 3200 },
+    appType: 'spa'
+  });
+  await server.listen();
+  console.log('Code explorer running at http://localhost:3200');
+}
+
+run();

--- a/packages/code-explorer/index.html
+++ b/packages/code-explorer/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Code Explorer</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/index.tsx"></script>
+  </body>
+</html>

--- a/packages/code-explorer/scan.js
+++ b/packages/code-explorer/scan.js
@@ -1,0 +1,40 @@
+import fs from 'fs';
+import path from 'path';
+import ts from 'typescript';
+
+function collectFiles(dir, files = []) {
+  for (const entry of fs.readdirSync(dir)) {
+    const full = path.join(dir, entry);
+    const stat = fs.statSync(full);
+    if (stat.isDirectory()) {
+      if (entry === 'node_modules' || entry.startsWith('.')) continue;
+      collectFiles(full, files);
+    } else if (/\.(ts|tsx|js|jsx)$/.test(entry)) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+function parseFile(file) {
+  const sourceText = fs.readFileSync(file, 'utf8');
+  const sourceFile = ts.createSourceFile(file, sourceText, ts.ScriptTarget.Latest, true);
+  const functions = [];
+  function visit(node) {
+    if (ts.isFunctionDeclaration(node) && node.name) {
+      functions.push({
+        name: node.name.text,
+        params: node.parameters.map(p => p.name.getText()),
+        returnType: node.type ? node.type.getText() : 'any'
+      });
+    }
+    ts.forEachChild(node, visit);
+  }
+  visit(sourceFile);
+  return { file, functions };
+}
+
+export function scan(dir) {
+  const files = collectFiles(dir);
+  return files.map(parseFile);
+}

--- a/packages/code-explorer/src/index.tsx
+++ b/packages/code-explorer/src/index.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { DndContext, useDraggable, useDroppable } from '@dnd-kit/core';
+
+type FuncInfo = { file: string; functions: { name: string; params: string[]; returnType: string }[] };
+
+function App() {
+  const [data, setData] = React.useState<FuncInfo[]>([]);
+  const [items, setItems] = React.useState<any[]>([]);
+
+  React.useEffect(() => {
+    fetch('/api/data').then(r => r.json()).then(setData);
+  }, []);
+
+  const handleDragEnd = (event: any) => {
+    if (event.over && event.over.id === 'canvas') {
+      setItems([...items, event.active.data.current]);
+    }
+  };
+
+  return (
+    <DndContext onDragEnd={handleDragEnd}>
+      <div style={{ display: 'flex', gap: 16 }}>
+        <div style={{ width: 300, overflowY: 'auto', maxHeight: '80vh' }}>
+          {data.map((f) => (
+            <div key={f.file} style={{ marginBottom: 8 }}>
+              <strong>{f.file}</strong>
+              {f.functions.map(func => (
+                <DraggableFunc key={f.file + func.name} func={func} />
+              ))}
+            </div>
+          ))}
+        </div>
+        <Canvas items={items} />
+      </div>
+    </DndContext>
+  );
+}
+
+function DraggableFunc({ func }: { func: any }) {
+  const { attributes, listeners, setNodeRef, transform } = useDraggable({ id: func.name, data: func });
+  const style = { transform: transform ? `translate3d(${transform.x}px, ${transform.y}px, 0)` : undefined };
+  return (
+    <div ref={setNodeRef} style={{ padding: 4, border: '1px solid #ccc', marginTop: 4, cursor: 'grab', ...style }} {...listeners} {...attributes}>
+      {func.name}({func.params.join(', ')})
+    </div>
+  );
+}
+
+function Canvas({ items }: { items: any[] }) {
+  const { isOver, setNodeRef } = useDroppable({ id: 'canvas' });
+  const exportConfig = () => {
+    const json = JSON.stringify(items, null, 2);
+    const blob = new Blob([json], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'structure.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+  return (
+    <div ref={setNodeRef} style={{ flex: 1, padding: 16, border: '2px dashed #999', background: isOver ? '#f0f0f0' : '#fff' }}>
+      <h3>Canvas</h3>
+      {items.map((func, idx) => (
+        <div key={idx} style={{ padding: 4, border: '1px solid #ddd', marginBottom: 4 }}>
+          {func.name}
+        </div>
+      ))}
+      <button onClick={exportConfig} style={{ marginTop: 8 }}>Export JSON</button>
+    </div>
+  );
+}
+
+const root = createRoot(document.getElementById('root')!);
+root.render(<App />);


### PR DESCRIPTION
## Summary
- scaffold Vite-powered card-builder tool with drag-and-drop card preview and JSON export
- add code-explorer utility that indexes TypeScript/JavaScript and exposes drag-and-drop UI
- document how to run optional self-contained tools

## Testing
- `npm run card-builder`
- `npm run code-explorer -- client`
- `npm run dev` *(fails: DATABASE_URL must be set)*

------
https://chatgpt.com/codex/tasks/task_e_68b8792b0e5c83319cfa1c974f1d7319