### PR TITLE
Remove display config options and fix card content overrides

### DIFF
--- a/client/src/components/presentation-viewer.tsx
+++ b/client/src/components/presentation-viewer.tsx
@@ -149,6 +149,10 @@ function DynamicFormsSlide({ forms, siteId, onPrevSlide, onNextSlide }: DynamicF
             // Use override color first, then template color, then default to blue
             const effectiveColor = formAssignment.overrideConfig?.color || config.color || 'blue';
             const colorTheme = getFormColor(effectiveColor);
+            const effectiveTitle = formAssignment.overrideConfig?.title || config.title || formTemplate.name;
+            const effectiveSubtitle = formAssignment.overrideConfig?.subtitle ?? config.subtitle;
+            const effectiveDescription = formAssignment.overrideConfig?.description || config.description || formTemplate.description || 'Click to learn more and get in touch';
+            const buttonText = formAssignment.overrideConfig?.buttonText || config.buttonText || 'Get Started';
             
             return (
               <Card 
@@ -162,27 +166,27 @@ function DynamicFormsSlide({ forms, siteId, onPrevSlide, onNextSlide }: DynamicF
                     {getFormIcon(config.icon || 'file')}
                   </div>
                   <CardTitle className="text-xl text-white mb-2">
-                    {config.title || formTemplate.name}
+                    {effectiveTitle}
                   </CardTitle>
-                  {config.subtitle && (
+                  {effectiveSubtitle && (
                     <p className="text-slate-400 text-xs mb-2 font-medium">
-                      {config.subtitle}
+                      {effectiveSubtitle}
                     </p>
                   )}
                   <CardDescription className="text-slate-300 text-sm whitespace-pre-line">
-                    {config.description || formTemplate.description || 'Click to learn more and get in touch'}
+                    {effectiveDescription}
                   </CardDescription>
                 </CardHeader>
-                
+
                 <CardContent className="text-center pt-0 mt-auto">
-                  <Button 
+                  <Button
                     className={`w-full ${colorTheme.button} text-white font-semibold transition-all duration-300`}
                     onClick={(e) => {
                       e.stopPropagation();
                       handleFormCardClick(formAssignment);
                     }}
                   >
-                    {config.buttonText || 'Get Started'}
+                    {buttonText}
                     <ArrowRight className="w-4 h-4 ml-2" />
                   </Button>
                 </CardContent>

--- a/client/src/pages/dynamic-site.tsx
+++ b/client/src/pages/dynamic-site.tsx
@@ -25,6 +25,7 @@ import { z } from 'zod';
 import { PresentationViewer } from '@/components/presentation-viewer';
 import { ComingSoon } from '@/components/coming-soon';
 import { VideoCard } from '@/components/video-card';
+import { YouTubeCard } from '@/components/youtube-card';
 import { useAuth } from '@/hooks/use-auth';
 import type { Site } from '@shared/site-schema';
 
@@ -1109,20 +1110,25 @@ function PitchSiteInterface({ site, siteId, showPresentation, setShowPresentatio
                           // Use override color first, then template color, then default to blue
                           const effectiveColor = cardAssignment.overrideConfig?.color || config.color || 'blue';
                           const colorTheme = getFormColor(effectiveColor);
-                          
+
                           // Get button text - for hyperlinks, default is "Visit" instead of "Get Started"
                           const defaultButtonText = cardType === 'hyperlink' ? 'Visit' : 'Get Started';
                           const buttonText = cardAssignment.overrideConfig?.buttonText || config.buttonText || defaultButtonText;
-                          
+
+                          // Content overrides
+                          const effectiveTitle = cardAssignment.overrideConfig?.title || config.title || cardTemplate.name;
+                          const effectiveSubtitle = cardAssignment.overrideConfig?.subtitle ?? config.subtitle;
+                          const effectiveDescription = cardAssignment.overrideConfig?.description || config.description || cardTemplate.description || (cardType === 'hyperlink' ? 'Click to visit the link' : 'Click to learn more and get in touch');
+
                           // Render video cards (YouTube and Vimeo) differently from standard cards
                           if (cardType === 'youtube' || cardType === 'vimeo') {
                             return (
-                              <div 
+                              <div
                                 key={cardAssignment.id}
                                 className="w-full max-w-md mx-auto"
                                 data-testid={`card-${cardType}-${cardTemplate.name.toLowerCase().replace(/\s+/g, '-')}`}
                               >
-                                <VideoCard 
+                                <VideoCard
                                   template={cardTemplate}
                                   className="transition-all duration-300 hover:scale-105"
                                 />
@@ -1132,7 +1138,7 @@ function PitchSiteInterface({ site, siteId, showPresentation, setShowPresentatio
 
                           // Standard cards for forms and hyperlinks
                           return (
-                            <Card 
+                            <Card
                               key={cardAssignment.id}
                               className={`bg-gradient-to-br from-slate-800/50 to-slate-900/50 border-slate-600 backdrop-blur-sm hover:border-slate-500 transition-all duration-300 cursor-pointer transform hover:scale-105 flex flex-col h-full ${colorTheme.shadow}`}
                               onClick={() => handleCardClick(cardAssignment)}
@@ -1142,9 +1148,9 @@ function PitchSiteInterface({ site, siteId, showPresentation, setShowPresentatio
                                 {/* Logo for hyperlink cards or icon for form cards */}
                                 {cardType === 'hyperlink' && config.logo ? (
                                   <div className="w-20 h-20 rounded-xl mx-auto mb-4 flex items-center justify-center border-2 border-slate-600 bg-white p-2">
-                                    <img 
-                                      src={config.logo} 
-                                      alt={`${config.title || cardTemplate.name} logo`}
+                                    <img
+                                      src={config.logo}
+                                      alt={`${effectiveTitle} logo`}
                                       className="max-w-full max-h-full object-contain"
                                     />
                                   </div>
@@ -1154,20 +1160,20 @@ function PitchSiteInterface({ site, siteId, showPresentation, setShowPresentatio
                                   </div>
                                 )}
                                 <CardTitle className="text-xl text-white mb-2">
-                                  {config.title || cardTemplate.name}
+                                  {effectiveTitle}
                                 </CardTitle>
-                                {config.subtitle && (
+                                {effectiveSubtitle && (
                                   <p className="text-slate-400 text-xs mb-2 font-medium">
-                                    {config.subtitle}
+                                    {effectiveSubtitle}
                                   </p>
                                 )}
                                 <CardDescription className="text-slate-300 text-sm whitespace-pre-line">
-                                  {config.description || cardTemplate.description || (cardType === 'hyperlink' ? 'Click to visit the link' : 'Click to learn more and get in touch')}
+                                  {effectiveDescription}
                                 </CardDescription>
                               </CardHeader>
-                              
+
                               <CardContent className="text-center pt-0 mt-auto">
-                                <Button 
+                                <Button
                                   className={`w-full ${colorTheme.button} text-white font-semibold transition-all duration-300`}
                                   onClick={(e) => {
                                     e.stopPropagation();
@@ -1175,8 +1181,8 @@ function PitchSiteInterface({ site, siteId, showPresentation, setShowPresentatio
                                   }}
                                 >
                                   {buttonText}
-                                  {cardType === 'hyperlink' ? 
-                                    <ExternalLink className="w-4 h-4 ml-2" /> : 
+                                  {cardType === 'hyperlink' ?
+                                    <ExternalLink className="w-4 h-4 ml-2" /> :
                                     <ArrowRight className="w-4 h-4 ml-2" />
                                   }
                                 </Button>
@@ -1221,6 +1227,9 @@ function PitchSiteInterface({ site, siteId, showPresentation, setShowPresentatio
                         const colorTheme = getFormColor(effectiveColor);
                         const defaultButtonText = cardType === 'hyperlink' ? 'Visit' : 'Get Started';
                         const buttonText = cardAssignment.overrideConfig?.buttonText || config.buttonText || defaultButtonText;
+                        const effectiveTitle = cardAssignment.overrideConfig?.title || config.title || cardTemplate.name;
+                        const effectiveSubtitle = cardAssignment.overrideConfig?.subtitle ?? config.subtitle;
+                        const effectiveDescription = cardAssignment.overrideConfig?.description || config.description || cardTemplate.description || (cardType === 'hyperlink' ? 'Click to visit the link' : 'Click to learn more and get in touch');
                         
                         if (cardType === 'youtube') {
                           return (
@@ -1245,29 +1254,29 @@ function PitchSiteInterface({ site, siteId, showPresentation, setShowPresentatio
                             data-testid={`card-${cardType}-${cardTemplate.name.toLowerCase().replace(/\s+/g, '-')}`}
                           >
                             <CardHeader className="text-center pb-4 flex-grow">
-                              {cardType === 'hyperlink' && config.logo ? (
-                                <div className="w-20 h-20 rounded-xl mx-auto mb-4 flex items-center justify-center border-2 border-slate-600 bg-white p-2">
-                                  <img 
-                                    src={config.logo} 
-                                    alt={`${config.title || cardTemplate.name} logo`}
-                                    className="max-w-full max-h-full object-contain"
-                                  />
-                                </div>
-                              ) : (
-                                <div className={`w-20 h-20 rounded-xl mx-auto mb-4 flex items-center justify-center border-2 ${colorTheme.icon}`}>
-                                  {getFormIcon(config.icon || 'file')}
-                                </div>
-                              )}
+                                {cardType === 'hyperlink' && config.logo ? (
+                                  <div className="w-20 h-20 rounded-xl mx-auto mb-4 flex items-center justify-center border-2 border-slate-600 bg-white p-2">
+                                    <img
+                                      src={config.logo}
+                                      alt={`${effectiveTitle} logo`}
+                                      className="max-w-full max-h-full object-contain"
+                                    />
+                                  </div>
+                                ) : (
+                                  <div className={`w-20 h-20 rounded-xl mx-auto mb-4 flex items-center justify-center border-2 ${colorTheme.icon}`}>
+                                    {getFormIcon(config.icon || 'file')}
+                                  </div>
+                                )}
                               <CardTitle className="text-xl text-white mb-2">
-                                {config.title || cardTemplate.name}
+                                {effectiveTitle}
                               </CardTitle>
-                              {config.subtitle && (
+                              {effectiveSubtitle && (
                                 <p className="text-slate-400 text-xs mb-2 font-medium">
-                                  {config.subtitle}
+                                  {effectiveSubtitle}
                                 </p>
                               )}
                               <CardDescription className="text-slate-300 text-sm whitespace-pre-line">
-                                {config.description || cardTemplate.description || (cardType === 'hyperlink' ? 'Click to visit the link' : 'Click to learn more and get in touch')}
+                                {effectiveDescription}
                               </CardDescription>
                             </CardHeader>
                             

--- a/client/src/pages/site-admin.tsx
+++ b/client/src/pages/site-admin.tsx
@@ -11,7 +11,7 @@ import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, Di
 import { Badge } from '@/components/ui/badge';
 import { Textarea } from '@/components/ui/textarea';
 import { ScrollArea } from '@/components/ui/scroll-area';
-import { Settings, Users, BarChart3, Eye, UserPlus, X, FileText, Shield, ExternalLink, Plus, Trash2, Edit, Images, Globe, Download, CheckCircle, GripVertical, Monitor, ChevronUp, ChevronDown, Folder } from 'lucide-react';
+import { Settings, Users, BarChart3, Eye, UserPlus, X, FileText, Shield, ExternalLink, Plus, Trash2, Edit, Images, Globe, Download, CheckCircle, GripVertical, ChevronUp, ChevronDown, Folder } from 'lucide-react';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import { useToast } from '@/hooks/use-toast';
 import { apiRequest, queryClient } from '@/lib/queryClient';
@@ -72,20 +72,20 @@ function SortableFormItem({ assignment, template, onRemove, onUpdate }: Sortable
   const [isExpanded, setIsExpanded] = useState(false);
   const [colorOverride, setColorOverride] = useState(assignment.overrideConfig?.color || '');
   const [includeInPresentation, setIncludeInPresentation] = useState(assignment.overrideConfig?.includeInPresentation || false);
-  
+
   // Content customization state
   const [titleOverride, setTitleOverride] = useState(assignment.overrideConfig?.title || '');
   const [subtitleOverride, setSubtitleOverride] = useState(assignment.overrideConfig?.subtitle || '');
   const [descriptionOverride, setDescriptionOverride] = useState(assignment.overrideConfig?.description || '');
+
+  useEffect(() => {
+    setColorOverride(assignment.overrideConfig?.color || '');
+    setIncludeInPresentation(assignment.overrideConfig?.includeInPresentation || false);
+    setTitleOverride(assignment.overrideConfig?.title || '');
+    setSubtitleOverride(assignment.overrideConfig?.subtitle || '');
+    setDescriptionOverride(assignment.overrideConfig?.description || '');
+  }, [assignment.overrideConfig?.color, assignment.overrideConfig?.includeInPresentation, assignment.overrideConfig?.title, assignment.overrideConfig?.subtitle, assignment.overrideConfig?.description]);
   
-  // Display Configuration State
-  const [displaySize, setDisplaySize] = useState(assignment.overrideConfig?.displaySize || 'medium');
-  const [displayStyle, setDisplayStyle] = useState(assignment.overrideConfig?.displayStyle || 'default');
-  const [showIcon, setShowIcon] = useState(assignment.overrideConfig?.showIcon ?? true);
-  const [showSubtitle, setShowSubtitle] = useState(assignment.overrideConfig?.showSubtitle ?? true);
-  const [borderStyle, setBorderStyle] = useState(assignment.overrideConfig?.borderStyle || 'none');
-  const [shadowLevel, setShadowLevel] = useState(assignment.overrideConfig?.shadowLevel || 'none');
-  const [customCss, setCustomCss] = useState(assignment.overrideConfig?.customCss || '');
 
   const {
     attributes,
@@ -108,7 +108,7 @@ function SortableFormItem({ assignment, template, onRemove, onUpdate }: Sortable
     setColorOverride(finalColor);
     onUpdate(assignment.id, {
       overrideConfig: {
-        ...assignment.overrideConfig,
+        ...(assignment.overrideConfig || {}),
         color: finalColor
       }
     });
@@ -118,82 +118,12 @@ function SortableFormItem({ assignment, template, onRemove, onUpdate }: Sortable
     setIncludeInPresentation(checked);
     onUpdate(assignment.id, {
       overrideConfig: {
-        ...assignment.overrideConfig,
+        ...(assignment.overrideConfig || {}),
         includeInPresentation: checked
       }
     });
   };
 
-  // Display Configuration Update Handlers
-  const handleDisplaySizeChange = (size: string) => {
-    setDisplaySize(size);
-    onUpdate(assignment.id, {
-      overrideConfig: {
-        ...assignment.overrideConfig,
-        displaySize: size
-      }
-    });
-  };
-
-  const handleDisplayStyleChange = (style: string) => {
-    setDisplayStyle(style);
-    onUpdate(assignment.id, {
-      overrideConfig: {
-        ...assignment.overrideConfig,
-        displayStyle: style
-      }
-    });
-  };
-
-  const handleShowIconToggle = (checked: boolean) => {
-    setShowIcon(checked);
-    onUpdate(assignment.id, {
-      overrideConfig: {
-        ...assignment.overrideConfig,
-        showIcon: checked
-      }
-    });
-  };
-
-  const handleShowSubtitleToggle = (checked: boolean) => {
-    setShowSubtitle(checked);
-    onUpdate(assignment.id, {
-      overrideConfig: {
-        ...assignment.overrideConfig,
-        showSubtitle: checked
-      }
-    });
-  };
-
-  const handleBorderStyleChange = (border: string) => {
-    setBorderStyle(border);
-    onUpdate(assignment.id, {
-      overrideConfig: {
-        ...assignment.overrideConfig,
-        borderStyle: border
-      }
-    });
-  };
-
-  const handleShadowLevelChange = (shadow: string) => {
-    setShadowLevel(shadow);
-    onUpdate(assignment.id, {
-      overrideConfig: {
-        ...assignment.overrideConfig,
-        shadowLevel: shadow
-      }
-    });
-  };
-
-  const handleCustomCssChange = (css: string) => {
-    setCustomCss(css);
-    onUpdate(assignment.id, {
-      overrideConfig: {
-        ...assignment.overrideConfig,
-        customCss: css
-      }
-    });
-  };
 
   const colorOptions = [
     { name: 'Blue', value: 'blue', class: 'bg-blue-500' },
@@ -351,13 +281,17 @@ function SortableFormItem({ assignment, template, onRemove, onUpdate }: Sortable
                     <Label className="text-sm font-medium text-slate-300">Card Title Override</Label>
                     <input
                       type="text"
-                      value={assignment.overrideConfig?.title || ''}
-                      onChange={(e) => onUpdate(assignment.id, {
-                        overrideConfig: {
-                          ...assignment.overrideConfig,
-                          title: e.target.value
-                        }
-                      })}
+                      value={titleOverride}
+                      onChange={(e) => {
+                        const value = e.target.value;
+                        setTitleOverride(value);
+                        onUpdate(assignment.id, {
+                          overrideConfig: {
+                            ...(assignment.overrideConfig || {}),
+                            title: value
+                          }
+                        });
+                      }}
                       placeholder={template?.config?.title || template?.name || 'Default title'}
                       className="w-full px-3 py-2 bg-slate-800/50 border border-slate-600 rounded text-slate-300 placeholder-slate-500 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
                       data-testid={`input-title-override-${assignment.id}`}
@@ -368,13 +302,17 @@ function SortableFormItem({ assignment, template, onRemove, onUpdate }: Sortable
                     <Label className="text-sm font-medium text-slate-300">Card Subtitle Override</Label>
                     <input
                       type="text"
-                      value={assignment.overrideConfig?.subtitle || ''}
-                      onChange={(e) => onUpdate(assignment.id, {
-                        overrideConfig: {
-                          ...assignment.overrideConfig,
-                          subtitle: e.target.value
-                        }
-                      })}
+                      value={subtitleOverride}
+                      onChange={(e) => {
+                        const value = e.target.value;
+                        setSubtitleOverride(value);
+                        onUpdate(assignment.id, {
+                          overrideConfig: {
+                            ...(assignment.overrideConfig || {}),
+                            subtitle: value
+                          }
+                        });
+                      }}
                       placeholder={template?.config?.subtitle || 'Default subtitle'}
                       className="w-full px-3 py-2 bg-slate-800/50 border border-slate-600 rounded text-slate-300 placeholder-slate-500 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
                       data-testid={`input-subtitle-override-${assignment.id}`}
@@ -384,13 +322,17 @@ function SortableFormItem({ assignment, template, onRemove, onUpdate }: Sortable
                   <div>
                     <Label className="text-sm font-medium text-slate-300">Card Description Override</Label>
                     <textarea
-                      value={assignment.overrideConfig?.description || ''}
-                      onChange={(e) => onUpdate(assignment.id, {
-                        overrideConfig: {
-                          ...assignment.overrideConfig,
-                          description: e.target.value
-                        }
-                      })}
+                      value={descriptionOverride}
+                      onChange={(e) => {
+                        const value = e.target.value;
+                        setDescriptionOverride(value);
+                        onUpdate(assignment.id, {
+                          overrideConfig: {
+                            ...(assignment.overrideConfig || {}),
+                            description: value
+                          }
+                        });
+                      }}
                       placeholder={template?.config?.description || 'Default description'}
                       className="w-full px-3 py-2 bg-slate-800/50 border border-slate-600 rounded text-slate-300 placeholder-slate-500 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
                       rows={3}
@@ -406,148 +348,6 @@ function SortableFormItem({ assignment, template, onRemove, onUpdate }: Sortable
               </div>
             </div>
 
-            {/* Display Configuration Section */}
-            <div className="border-t border-slate-600 pt-6 mt-6 space-y-4">
-              <Label className="text-base font-medium text-white flex items-center gap-2">
-                <Monitor className="w-4 h-4" />
-                Display Configuration
-              </Label>
-              
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                {/* Display Size */}
-                <div className="space-y-3">
-                  <Label className="text-sm font-medium text-slate-300">Display Size</Label>
-                  <div className="grid grid-cols-3 gap-2">
-                    {['small', 'medium', 'large'].map((size) => (
-                      <Button
-                        key={size}
-                        variant={displaySize === size ? "default" : "outline"}
-                        size="sm"
-                        className={`${displaySize === size 
-                          ? 'ring-2 ring-blue-400 ring-offset-2 ring-offset-slate-800' 
-                          : 'border-slate-600 hover:bg-slate-600'}`}
-                        onClick={() => handleDisplaySizeChange(size)}
-                        data-testid={`button-size-${size}-${assignment.id}`}
-                      >
-                        <span className="text-xs capitalize">{size}</span>
-                      </Button>
-                    ))}
-                  </div>
-                </div>
-
-                {/* Display Style */}
-                <div className="space-y-3">
-                  <Label className="text-sm font-medium text-slate-300">Display Style</Label>
-                  <div className="grid grid-cols-3 gap-2">
-                    {['default', 'compact', 'featured'].map((style) => (
-                      <Button
-                        key={style}
-                        variant={displayStyle === style ? "default" : "outline"}
-                        size="sm"
-                        className={`${displayStyle === style 
-                          ? 'ring-2 ring-blue-400 ring-offset-2 ring-offset-slate-800' 
-                          : 'border-slate-600 hover:bg-slate-600'}`}
-                        onClick={() => handleDisplayStyleChange(style)}
-                        data-testid={`button-style-${style}-${assignment.id}`}
-                      >
-                        <span className="text-xs capitalize">{style}</span>
-                      </Button>
-                    ))}
-                  </div>
-                </div>
-
-                {/* Visibility Toggles */}
-                <div className="space-y-3">
-                  <Label className="text-sm font-medium text-slate-300">Visibility Options</Label>
-                  <div className="space-y-2">
-                    <div className="flex items-center space-x-2 p-2 bg-slate-800/50 rounded border border-slate-600">
-                      <input
-                        type="checkbox"
-                        id={`showIcon-${assignment.id}`}
-                        checked={showIcon}
-                        onChange={(e) => handleShowIconToggle(e.target.checked)}
-                        className="rounded border-slate-600 bg-slate-700 text-blue-600 focus:ring-blue-500"
-                        data-testid={`checkbox-show-icon-${assignment.id}`}
-                      />
-                      <Label htmlFor={`showIcon-${assignment.id}`} className="text-xs text-slate-300 cursor-pointer">
-                        Show Icon
-                      </Label>
-                    </div>
-                    <div className="flex items-center space-x-2 p-2 bg-slate-800/50 rounded border border-slate-600">
-                      <input
-                        type="checkbox"
-                        id={`showSubtitle-${assignment.id}`}
-                        checked={showSubtitle}
-                        onChange={(e) => handleShowSubtitleToggle(e.target.checked)}
-                        className="rounded border-slate-600 bg-slate-700 text-blue-600 focus:ring-blue-500"
-                        data-testid={`checkbox-show-subtitle-${assignment.id}`}
-                      />
-                      <Label htmlFor={`showSubtitle-${assignment.id}`} className="text-xs text-slate-300 cursor-pointer">
-                        Show Subtitle
-                      </Label>
-                    </div>
-                  </div>
-                </div>
-
-                {/* Border Style */}
-                <div className="space-y-3">
-                  <Label className="text-sm font-medium text-slate-300">Border Style</Label>
-                  <div className="grid grid-cols-2 gap-2">
-                    {['none', 'solid', 'dashed', 'gradient'].map((border) => (
-                      <Button
-                        key={border}
-                        variant={borderStyle === border ? "default" : "outline"}
-                        size="sm"
-                        className={`${borderStyle === border 
-                          ? 'ring-2 ring-blue-400 ring-offset-2 ring-offset-slate-800' 
-                          : 'border-slate-600 hover:bg-slate-600'}`}
-                        onClick={() => handleBorderStyleChange(border)}
-                        data-testid={`button-border-${border}-${assignment.id}`}
-                      >
-                        <span className="text-xs capitalize">{border}</span>
-                      </Button>
-                    ))}
-                  </div>
-                </div>
-
-                {/* Shadow Level */}
-                <div className="space-y-3">
-                  <Label className="text-sm font-medium text-slate-300">Shadow Level</Label>
-                  <div className="grid grid-cols-2 gap-2">
-                    {['none', 'subtle', 'medium', 'strong'].map((shadow) => (
-                      <Button
-                        key={shadow}
-                        variant={shadowLevel === shadow ? "default" : "outline"}
-                        size="sm"
-                        className={`${shadowLevel === shadow 
-                          ? 'ring-2 ring-blue-400 ring-offset-2 ring-offset-slate-800' 
-                          : 'border-slate-600 hover:bg-slate-600'}`}
-                        onClick={() => handleShadowLevelChange(shadow)}
-                        data-testid={`button-shadow-${shadow}-${assignment.id}`}
-                      >
-                        <span className="text-xs capitalize">{shadow}</span>
-                      </Button>
-                    ))}
-                  </div>
-                </div>
-
-                {/* Custom CSS */}
-                <div className="space-y-3 md:col-span-2">
-                  <Label className="text-sm font-medium text-slate-300">Custom CSS Classes</Label>
-                  <input
-                    type="text"
-                    value={customCss}
-                    onChange={(e) => handleCustomCssChange(e.target.value)}
-                    placeholder="e.g., hover:scale-105 transition-transform"
-                    className="w-full px-3 py-2 bg-slate-800/50 border border-slate-600 rounded text-slate-300 placeholder-slate-500 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                    data-testid={`input-custom-css-${assignment.id}`}
-                  />
-                  <p className="text-xs text-slate-400">
-                    Add custom Tailwind CSS classes to further customize the card appearance
-                  </p>
-                </div>
-              </div>
-            </div>
           </div>
         )}
       </CardContent>


### PR DESCRIPTION
## Summary
- drop unused display configuration section from site admin card editor
- fix content customization inputs to sync with server
- apply title/subtitle/description overrides when rendering cards and presentation slides

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: TypeScript errors in server/storage.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b896aad0108331bc56c732b8f61142