### PR TITLE
fix: update password placeholder text

### DIFF
--- a/client/src/pages/site-manager.tsx
+++ b/client/src/pages/site-manager.tsx
@@ -675,7 +675,7 @@ export function SiteManager() {
                         name="password"
                         type="password"
                         defaultValue={editingSite.password || ''}
-                        placeholder="Leave empty to use global password"
+                        placeholder="(optional)"
                         className="bg-slate-700/50 border-slate-600 focus:border-blue-500"
                         data-testid="input-edit-password"
                       />


### PR DESCRIPTION
## Summary
- update site manager custom password placeholder to show (optional)

## Testing
- `npm test`
- `npm run check` *(fails: Cannot find name 'siteAccessControl', and other type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b8cbc8b80c8331961c21478b55b5e0