### PR TITLE
feat(code-explorer): add home action cards and import dialog

### DIFF
--- a/packages/code-explorer/src/App.tsx
+++ b/packages/code-explorer/src/App.tsx
@@ -1,4 +1,16 @@
 import React, { useState } from "react";
+import { Folder, Github, FilePlus } from "lucide-react";
+import { ActionCard } from "./components/ActionCard";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
 
 interface TreeNode {
   name: string;
@@ -27,11 +39,14 @@ function FileTree({ node }: { node: TreeNode }) {
 }
 
 export function CodeExplorerApp() {
-  const [repo, setRepo] = useState("");
+  const [screen, setScreen] = useState<"home" | "explorer">("home");
   const [tree, setTree] = useState<TreeNode | null>(null);
   const [loading, setLoading] = useState(false);
+  const [showImport, setShowImport] = useState(false);
+  const [repoUrl, setRepoUrl] = useState("");
+  const [error, setError] = useState("");
 
-  async function handleScan() {
+  async function handleScan(repo: string) {
     setLoading(true);
     const res = await fetch("/explorer/api/clone", {
       method: "POST",
@@ -41,27 +56,77 @@ export function CodeExplorerApp() {
     const data = await res.json();
     setTree(data);
     setLoading(false);
+    setScreen("explorer");
+  }
+
+  function handleImport() {
+    if (!/^https:\/\/github.com\/.+/.test(repoUrl)) {
+      setError("Please enter a valid GitHub URL");
+      return;
+    }
+    setShowImport(false);
+    setError("");
+    handleScan(repoUrl);
+  }
+
+  if (screen === "home") {
+    return (
+      <div className="p-6 flex justify-center">
+        <div className="grid gap-6 md:grid-cols-3">
+          <ActionCard
+            icon={Folder}
+            title="Load local directory"
+            description="Open a folder from your device"
+            cta="Browse"
+            onClick={() => alert("File system access not available in this demo")}
+          />
+          <ActionCard
+            icon={Github}
+            title="Import GitHub repository"
+            description="Clone a public repository"
+            cta="Import"
+            onClick={() => setShowImport(true)}
+          />
+          <ActionCard
+            icon={FilePlus}
+            title="Start a new file"
+            description="Create a blank file to edit"
+            cta="Create"
+            onClick={() => {
+              setTree(null);
+              setScreen("explorer");
+            }}
+          />
+        </div>
+        <Dialog open={showImport} onOpenChange={setShowImport}>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Import repository</DialogTitle>
+              <DialogDescription>Enter a public GitHub URL.</DialogDescription>
+            </DialogHeader>
+            <Input
+              value={repoUrl}
+              onChange={(e) => setRepoUrl(e.target.value)}
+              placeholder="https://github.com/user/repo"
+            />
+            {error && <p className="text-sm text-red-500">{error}</p>}
+            <DialogFooter>
+              <Button onClick={handleImport}>Import</Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </div>
+    );
   }
 
   return (
     <div className="p-4">
-      <h1 className="text-xl mb-4">Code Explorer</h1>
-      <div className="flex gap-2 mb-4">
-        <input
-          value={repo}
-          onChange={(e) => setRepo(e.target.value)}
-          placeholder="https://github.com/user/repo.git"
-          className="border px-2 py-1 flex-grow"
-        />
-        <button
-          onClick={handleScan}
-          className="px-4 py-1 bg-blue-600 text-white"
-        >
-          Scan
-        </button>
-      </div>
+      <Button variant="outline" className="mb-4" onClick={() => setScreen("home")}>
+        Back
+      </Button>
       {loading && <p>Cloning...</p>}
-      {tree && <FileTree node={tree} />}
+      {tree ? <FileTree node={tree} /> : <p className="text-sm text-muted-foreground">No file loaded.</p>}
     </div>
   );
 }
+

--- a/packages/code-explorer/src/components/ActionCard.tsx
+++ b/packages/code-explorer/src/components/ActionCard.tsx
@@ -1,0 +1,29 @@
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import type { LucideIcon } from "lucide-react";
+
+interface ActionCardProps {
+  icon: LucideIcon;
+  title: string;
+  description: string;
+  cta: string;
+  onClick: () => void;
+}
+
+export function ActionCard({ icon: Icon, title, description, cta, onClick }: ActionCardProps) {
+  return (
+    <Card className="w-full max-w-sm transition-shadow hover:shadow-md">
+      <CardHeader className="text-center">
+        <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-gradient-to-br from-purple-500 to-indigo-500 text-white">
+          <Icon className="h-6 w-6" />
+        </div>
+        <CardTitle className="text-lg">{title}</CardTitle>
+        <CardDescription className="text-sm text-muted-foreground">{description}</CardDescription>
+      </CardHeader>
+      <CardContent className="flex justify-center">
+        <Button onClick={onClick}>{cta}</Button>
+      </CardContent>
+    </Card>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add reusable ActionCard component styled with gradients
- introduce Code Explorer home screen with cards for loading directories, importing GitHub repos, or starting a file
- show dialog for importing public GitHub repository and load tree view

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b90e8fbbd48331ad8d5d4252e353cb