### PR TITLE
feat(code-explorer): add searchable tree and code viewer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -70,6 +70,7 @@
         "passport": "^0.7.0",
         "passport-google-oauth20": "^2.0.0",
         "passport-local": "^1.0.0",
+        "prismjs": "^1.29.0",
         "qrcode": "^1.5.4",
         "react": "^18.3.1",
         "react-day-picker": "^8.10.1",
@@ -9093,6 +9094,15 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/prismjs": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
+      "integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/prop-types": {
       "version": "15.8.1",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "passport": "^0.7.0",
     "passport-google-oauth20": "^2.0.0",
     "passport-local": "^1.0.0",
+    "prismjs": "^1.29.0",
     "qrcode": "^1.5.4",
     "react": "^18.3.1",
     "react-day-picker": "^8.10.1",
@@ -96,6 +97,7 @@
     "@replit/vite-plugin-runtime-error-modal": "^0.0.3",
     "@tailwindcss/typography": "^0.5.15",
     "@tailwindcss/vite": "^4.1.3",
+    "@testing-library/react": "^15.0.0",
     "@types/connect-pg-simple": "^7.0.3",
     "@types/express": "4.17.21",
     "@types/express-session": "^1.18.0",
@@ -109,14 +111,13 @@
     "autoprefixer": "^10.4.20",
     "drizzle-kit": "^0.30.4",
     "esbuild": "^0.25.0",
+    "jsdom": "^24.0.0",
     "postcss": "^8.4.47",
     "tailwindcss": "^3.4.17",
     "tsx": "^4.19.1",
     "typescript": "5.6.3",
     "vite": "^5.4.19",
-    "vitest": "^1.3.1",
-    "@testing-library/react": "^15.0.0",
-    "jsdom": "^24.0.0"
+    "vitest": "^1.3.1"
   },
   "optionalDependencies": {
     "bufferutil": "^4.0.8"

--- a/packages/card-builder/src/Editor.tsx
+++ b/packages/card-builder/src/Editor.tsx
@@ -1,0 +1,542 @@
+import React, { useState, useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  DndContext,
+  useDraggable,
+  useDroppable,
+  DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  verticalListSortingStrategy,
+  useSortable,
+  arrayMove,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+
+// ---- Data element library -------------------------------------------------
+type DisplayMode = "display" | "input" | "edit";
+
+export type ElementDefinition = {
+  id: string;
+  label: string;
+  type: "text" | "number" | "image" | "button";
+  displayModes: DisplayMode[];
+  defaultProps: Record<string, any>;
+  validation?: Record<string, any>;
+};
+
+export const elementLibrary: ElementDefinition[] = [
+  {
+    id: "title",
+    label: "Title",
+    type: "text",
+    displayModes: ["display"],
+    defaultProps: { label: "Sample Title" },
+    validation: { required: true },
+  },
+  {
+    id: "description",
+    label: "Description",
+    type: "text",
+    displayModes: ["display"],
+    defaultProps: { label: "Sample description" },
+  },
+  {
+    id: "image",
+    label: "Image",
+    type: "image",
+    displayModes: ["display"],
+    defaultProps: {
+      src: "https://via.placeholder.com/300x100?text=Image",
+      alt: "sample image",
+    },
+  },
+  {
+    id: "input",
+    label: "Input Field",
+    type: "text",
+    displayModes: ["input"],
+    defaultProps: { label: "Field", placeholder: "Enter text" },
+    validation: { required: false },
+  },
+  {
+    id: "button",
+    label: "Button",
+    type: "button",
+    displayModes: ["display"],
+    defaultProps: { label: "Click" },
+  },
+];
+
+// ---- Palette item ---------------------------------------------------------
+function PaletteItem({ def }: { def: ElementDefinition }) {
+  const { attributes, listeners, setNodeRef, transform } = useDraggable({
+    id: def.id,
+    data: { from: "palette" },
+  });
+  const style = {
+    transform: CSS.Translate.toString(transform),
+  };
+  return (
+    <div
+      ref={setNodeRef}
+      {...listeners}
+      {...attributes}
+      style={style}
+      className="border p-2 mb-2 cursor-move bg-gray-200 text-sm"
+    >
+      {def.label}
+    </div>
+  );
+}
+
+// ---- Card canvas ----------------------------------------------------------
+export function CardCanvas({
+  theme,
+  shadow,
+  lighting,
+  animation,
+  children,
+}: {
+  theme: string;
+  shadow: string;
+  lighting: string;
+  animation: string;
+  children: React.ReactNode;
+}) {
+  const { setNodeRef } = useDroppable({ id: "card" });
+  const themeClass =
+    theme === "dark"
+      ? "bg-gray-900 text-white"
+      : theme === "neon"
+      ? "bg-gradient-to-r from-blue-500 to-pink-500 text-white"
+      : "bg-white text-black";
+  const shadowClass =
+    shadow === "soft" ? "shadow-md" : shadow === "strong" ? "shadow-xl" : "";
+  const lightingClass =
+    lighting === "glow"
+      ? "ring-2 ring-blue-400"
+      : lighting === "neon"
+      ? "ring-2 ring-pink-500"
+      : "";
+  const animationClass =
+    animation === "fade"
+      ? "animate-in fade-in"
+      : animation === "hover"
+      ? "transition-transform hover:scale-105"
+      : "";
+  return (
+    <div
+      ref={setNodeRef}
+      className={`w-96 min-h-[15rem] border p-4 flex flex-col gap-2 ${themeClass} ${shadowClass} ${lightingClass} ${animationClass}`}
+    >
+      {children}
+    </div>
+  );
+}
+
+// ---- Card item ------------------------------------------------------------
+export type ElementInstance = {
+  id: string;
+  elementId: string;
+  displayMode: DisplayMode;
+  props: Record<string, any>;
+};
+
+function CardItem({
+  item,
+  onRemove,
+  onSelect,
+  selected,
+}: {
+  item: ElementInstance;
+  onRemove: (id: string) => void;
+  onSelect: (id: string) => void;
+  selected: boolean;
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition } =
+    useSortable({ id: item.id, data: { from: "card" } });
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+  const def = elementLibrary.find((d) => d.id === item.elementId)!;
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      {...attributes}
+      {...listeners}
+      onClick={() => onSelect(item.id)}
+      className={`relative border p-2 bg-white text-black cursor-move ${
+        selected ? "ring-2 ring-blue-400" : ""
+      }`}
+    >
+      <button
+        onClick={() => onRemove(item.id)}
+        className="absolute -top-2 -right-2 bg-red-500 text-white rounded-full w-5 h-5 text-xs"
+      >
+        ×
+      </button>
+      {def.type === "text" && item.displayMode !== "input" && (
+        <div>{item.props.label || def.defaultProps.label}</div>
+      )}
+      {def.type === "text" && item.displayMode === "input" && (
+        <div>
+          <label className="block mb-1">
+            {item.props.label || def.defaultProps.label}
+          </label>
+          <input
+            className="border px-1"
+            placeholder={
+              item.props.placeholder || def.defaultProps.placeholder
+            }
+          />
+        </div>
+      )}
+      {def.type === "number" && (
+        <div>{item.props.value ?? 0}</div>
+      )}
+      {def.type === "image" && (
+        <img
+          src={item.props.src || def.defaultProps.src}
+          alt={item.props.alt || def.defaultProps.alt}
+          className="w-full h-24 object-cover"
+        />
+      )}
+      {def.type === "button" && (
+        <button className="px-2 py-1 border">
+          {item.props.label || def.defaultProps.label}
+        </button>
+      )}
+    </div>
+  );
+}
+
+// ---- Code serialization helpers -----------------------------------------
+export function buildConfig({
+  elements,
+  theme,
+  shadow,
+  lighting,
+  animation,
+}: {
+  elements: ElementInstance[];
+  theme: string;
+  shadow: string;
+  lighting: string;
+  animation: string;
+}) {
+  return {
+    theme,
+    shadow,
+    lighting,
+    animation,
+    elements: elements.map((el) => ({
+      id: el.id,
+      elementId: el.elementId,
+      displayMode: el.displayMode,
+      props: el.props,
+    })),
+  };
+}
+
+export function parseConfig(json: string): {
+  elements: ElementInstance[];
+  theme: string;
+  shadow: string;
+  lighting: string;
+  animation: string;
+} | null {
+  try {
+    const obj = JSON.parse(json);
+    if (!obj || typeof obj !== "object") return null;
+    const elements: ElementInstance[] = Array.isArray(obj.elements)
+      ? obj.elements
+          .map((el: any) => {
+            const def = elementLibrary.find((d) => d.id === el.elementId);
+            if (!def) return null;
+            const mode: DisplayMode = def.displayModes.includes(el.displayMode)
+              ? el.displayMode
+              : def.displayModes[0];
+            return {
+              id: el.id || Date.now().toString(),
+              elementId: def.id,
+              displayMode: mode,
+              props: el.props || {},
+            };
+          })
+          .filter(Boolean)
+      : [];
+    return {
+      elements,
+      theme: obj.theme || "light",
+      shadow: obj.shadow || "none",
+      lighting: obj.lighting || "none",
+      animation: obj.animation || "none",
+    };
+  } catch (e) {
+    return null;
+  }
+}
+
+// ---- Main app ------------------------------------------------------------
+export interface CardConfig {
+  elements: ElementInstance[];
+  theme: string;
+  shadow: string;
+  lighting: string;
+  animation: string;
+}
+
+export function CardEditor({ initial, onSave, onBack }: { initial?: CardConfig; onSave: (config: CardConfig) => void; onBack: () => void; }) {
+  const [elements, setElements] = useState<ElementInstance[]>([]);
+  const [theme, setTheme] = useState("light");
+  const [shadow, setShadow] = useState("none");
+  const [lighting, setLighting] = useState("none");
+  const [animation, setAnimation] = useState("none");
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [showCode, setShowCode] = useState(false);
+  const [code, setCode] = useState("{}");
+
+  useEffect(() => {
+    if (initial) {
+      setElements(initial.elements || []);
+      setTheme(initial.theme);
+      setShadow(initial.shadow);
+      setLighting(initial.lighting);
+      setAnimation(initial.animation);
+    }
+  }, [initial]);
+
+  useEffect(() => {
+    setCode(JSON.stringify(buildConfig({ elements, theme, shadow, lighting, animation }), null, 2));
+  }, [elements, theme, shadow, lighting, animation]);
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { over, active } = event;
+    if (!over) return;
+
+    // dropping from palette onto card
+    if (active.data.current?.from === "palette" && over.id === "card") {
+      const def = elementLibrary.find((d) => d.id === active.id);
+      if (!def) return;
+      let mode: DisplayMode = def.displayModes[0];
+      if (def.displayModes.length > 1) {
+        const input = window.prompt(
+          `Display mode (${def.displayModes.join(",")}):`,
+          def.displayModes[0],
+        );
+        if (input && def.displayModes.includes(input as DisplayMode)) {
+          mode = input as DisplayMode;
+        }
+      }
+      const instance: ElementInstance = {
+        id: Date.now().toString(),
+        elementId: def.id,
+        displayMode: mode,
+        props: { ...def.defaultProps },
+      };
+      setElements((els) => [...els, instance]);
+      return;
+    }
+
+    // reorder within card
+    if (active.data.current?.from === "card" && over.id !== "card") {
+      const oldIndex = elements.findIndex((el) => el.id === active.id);
+      const newIndex = elements.findIndex((el) => el.id === over.id);
+      if (oldIndex !== -1 && newIndex !== -1 && oldIndex !== newIndex) {
+        setElements((els) => arrayMove(els, oldIndex, newIndex));
+      }
+    }
+  };
+
+  const removeElement = (id: string) => {
+    setElements((els) => els.filter((el) => el.id !== id));
+    if (selectedId === id) setSelectedId(null);
+  };
+
+  const selected = elements.find((el) => el.id === selectedId) || null;
+
+  const updateSelected = (props: Record<string, any>) => {
+    if (!selected) return;
+    setElements((els) =>
+      els.map((el) =>
+        el.id === selected.id ? { ...el, props: { ...el.props, ...props } } : el,
+      ),
+    );
+  };
+
+  const exportJson = () => {
+    const data = JSON.stringify(
+      buildConfig({ elements, theme, shadow, lighting, animation }),
+      null,
+      2,
+    );
+    const blob = new Blob([data], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "card.json";
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const applyCode = () => {
+    const parsed = parseConfig(code);
+    if (!parsed) {
+      alert("Invalid JSON configuration");
+      return;
+    }
+    setElements(parsed.elements);
+    setTheme(parsed.theme);
+    setShadow(parsed.shadow);
+    setLighting(parsed.lighting);
+    setAnimation(parsed.animation);
+    setShowCode(false);
+  };
+
+  return (
+    <div className="p-4 space-y-4 text-sm">
+      <div className="flex gap-2 items-center flex-wrap">
+        <label>Theme:</label>
+        <select
+          value={theme}
+          onChange={(e) => setTheme(e.target.value)}
+          className="border px-2 py-1"
+        >
+          <option value="light">Light</option>
+          <option value="dark">Dark</option>
+          <option value="neon">Neon</option>
+        </select>
+
+        <label>Shadow:</label>
+        <select
+          value={shadow}
+          onChange={(e) => setShadow(e.target.value)}
+          className="border px-2 py-1"
+        >
+          <option value="none">None</option>
+          <option value="soft">Soft</option>
+          <option value="strong">Strong</option>
+        </select>
+
+        <label>Lighting:</label>
+        <select
+          value={lighting}
+          onChange={(e) => setLighting(e.target.value)}
+          className="border px-2 py-1"
+        >
+          <option value="none">None</option>
+          <option value="glow">Glow</option>
+          <option value="neon">Neon</option>
+        </select>
+
+        <label>Animation:</label>
+        <select
+          value={animation}
+          onChange={(e) => setAnimation(e.target.value)}
+          className="border px-2 py-1"
+        >
+          <option value="none">None</option>
+          <option value="fade">Fade In</option>
+          <option value="hover">Hover Grow</option>
+        </select>
+
+        <Button onClick={onBack} variant="outline">Back</Button>
+        <Button onClick={() => onSave(buildConfig({ elements, theme, shadow, lighting, animation }))}>Save</Button>
+        <Button onClick={() => setShowCode((v) => !v)} className="ml-auto">
+          {showCode ? "Design View" : "Code View"}
+        </Button>
+        <Button onClick={exportJson} variant="secondary">
+          Export JSON
+        </Button>
+      </div>
+
+      {showCode ? (
+        <div className="flex flex-col gap-2">
+          <textarea
+            value={code}
+            onChange={(e) => setCode(e.target.value)}
+            className="border p-2 font-mono h-80"
+          />
+          <div>
+            <Button onClick={applyCode} className="mr-2">Apply</Button>
+            <Button onClick={() => setShowCode(false)} variant="outline">Cancel</Button>
+          </div>
+        </div>
+      ) : (
+        <DndContext onDragEnd={handleDragEnd}>
+          <div className="flex gap-4">
+            <div>
+              {elementLibrary.map((def) => (
+                <PaletteItem key={def.id} def={def} />
+              ))}
+            </div>
+            <CardCanvas
+              theme={theme}
+              shadow={shadow}
+              lighting={lighting}
+              animation={animation}
+            >
+              <SortableContext
+                items={elements.map((e) => e.id)}
+                strategy={verticalListSortingStrategy}
+              >
+                {elements.map((el) => (
+                  <CardItem
+                    key={el.id}
+                    item={el}
+                    onRemove={removeElement}
+                    onSelect={(id) => setSelectedId(id)}
+                    selected={selectedId === el.id}
+                  />
+                ))}
+              </SortableContext>
+            </CardCanvas>
+          </div>
+        </DndContext>
+      )}
+
+      {selected && (
+        <div className="border p-2 w-96">
+          <div className="mb-2 font-bold">Element Properties</div>
+          <div className="flex flex-col gap-2">
+            <label className="flex gap-2 items-center">
+              <span className="w-24">Label</span>
+              <input
+                className="border px-2 py-1 flex-1"
+                value={selected.props.label || ""}
+                onChange={(e) => updateSelected({ label: e.target.value })}
+              />
+            </label>
+            {selected.displayMode === "input" && (
+              <label className="flex gap-2 items-center">
+                <span className="w-24">Placeholder</span>
+                <input
+                  className="border px-2 py-1 flex-1"
+                  value={selected.props.placeholder || ""}
+                  onChange={(e) =>
+                    updateSelected({ placeholder: e.target.value })
+                  }
+                />
+              </label>
+            )}
+            {selected.elementId === "image" && (
+              <label className="flex gap-2 items-center">
+                <span className="w-24">Image URL</span>
+                <input
+                  className="border px-2 py-1 flex-1"
+                  value={selected.props.src || ""}
+                  onChange={(e) => updateSelected({ src: e.target.value })}
+                />
+              </label>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/packages/card-builder/src/components/ActionCard.tsx
+++ b/packages/card-builder/src/components/ActionCard.tsx
@@ -1,0 +1,29 @@
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import type { LucideIcon } from "lucide-react";
+
+interface ActionCardProps {
+  icon: LucideIcon;
+  title: string;
+  description: string;
+  cta: string;
+  onClick: () => void;
+}
+
+export function ActionCard({ icon: Icon, title, description, cta, onClick }: ActionCardProps) {
+  return (
+    <Card className="w-full max-w-sm transition-shadow hover:shadow-md">
+      <CardHeader className="text-center">
+        <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-gradient-to-br from-purple-500 to-indigo-500 text-white">
+          <Icon className="h-6 w-6" />
+        </div>
+        <CardTitle className="text-lg">{title}</CardTitle>
+        <CardDescription className="text-sm text-muted-foreground">{description}</CardDescription>
+      </CardHeader>
+      <CardContent className="flex justify-center">
+        <Button onClick={onClick}>{cta}</Button>
+      </CardContent>
+    </Card>
+  );
+}
+

--- a/packages/code-explorer/src/App.tsx
+++ b/packages/code-explorer/src/App.tsx
@@ -1,37 +1,30 @@
 import React, { useState } from "react";
-
-interface TreeNode {
-  name: string;
-  path: string;
-  children?: TreeNode[];
-}
-
-function FileTree({ node }: { node: TreeNode }) {
-  if (!node.children) return null;
-  return (
-    <ul className="ml-4">
-      {node.children.map((child) => (
-        <li key={child.path}>
-          {child.children ? (
-            <>
-              <span className="font-semibold">{child.name}</span>
-              <FileTree node={child} />
-            </>
-          ) : (
-            <span>{child.name}</span>
-          )}
-        </li>
-      ))}
-    </ul>
-  );
-}
+import { Folder, Github, FilePlus } from "lucide-react";
+import { ActionCard } from "./components/ActionCard";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { FileTree, TreeNode } from "./components/FileTree";
+import { FileViewer } from "./components/FileViewer";
 
 export function CodeExplorerApp() {
-  const [repo, setRepo] = useState("");
+  const [screen, setScreen] = useState<"home" | "explorer">("home");
   const [tree, setTree] = useState<TreeNode | null>(null);
   const [loading, setLoading] = useState(false);
+  const [showImport, setShowImport] = useState(false);
+  const [repoUrl, setRepoUrl] = useState("");
+  const [error, setError] = useState("");
+  const [selected, setSelected] = useState<string | null>(null);
+  const [filter, setFilter] = useState("");
 
-  async function handleScan() {
+  async function handleScan(repo: string) {
     setLoading(true);
     const res = await fetch("/explorer/api/clone", {
       method: "POST",
@@ -41,27 +34,98 @@ export function CodeExplorerApp() {
     const data = await res.json();
     setTree(data);
     setLoading(false);
+    setScreen("explorer");
   }
 
-  return (
-    <div className="p-4">
-      <h1 className="text-xl mb-4">Code Explorer</h1>
-      <div className="flex gap-2 mb-4">
-        <input
-          value={repo}
-          onChange={(e) => setRepo(e.target.value)}
-          placeholder="https://github.com/user/repo.git"
-          className="border px-2 py-1 flex-grow"
-        />
-        <button
-          onClick={handleScan}
-          className="px-4 py-1 bg-blue-600 text-white"
-        >
-          Scan
-        </button>
+  function handleImport() {
+    if (!/^https:\/\/github.com\/.+/.test(repoUrl)) {
+      setError("Please enter a valid GitHub URL");
+      return;
+    }
+    setShowImport(false);
+    setError("");
+    handleScan(repoUrl);
+  }
+
+  if (screen === "home") {
+    return (
+      <div className="p-6 flex justify-center">
+        <div className="grid gap-6 md:grid-cols-3">
+          <ActionCard
+            icon={Folder}
+            title="Load local directory"
+            description="Open a folder from your device"
+            cta="Browse"
+            onClick={() => alert("File system access not available in this demo")}
+          />
+          <ActionCard
+            icon={Github}
+            title="Import GitHub repository"
+            description="Clone a public repository"
+            cta="Import"
+            onClick={() => setShowImport(true)}
+          />
+          <ActionCard
+            icon={FilePlus}
+            title="Start a new file"
+            description="Create a blank file to edit"
+            cta="Create"
+            onClick={() => {
+              setTree(null);
+              setScreen("explorer");
+            }}
+          />
+        </div>
+        <Dialog open={showImport} onOpenChange={setShowImport}>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Import repository</DialogTitle>
+              <DialogDescription>Enter a public GitHub URL.</DialogDescription>
+            </DialogHeader>
+            <Input
+              value={repoUrl}
+              onChange={(e) => setRepoUrl(e.target.value)}
+              placeholder="https://github.com/user/repo"
+            />
+            {error && <p className="text-sm text-red-500">{error}</p>}
+            <DialogFooter>
+              <Button onClick={handleImport}>Import</Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
       </div>
-      {loading && <p>Cloning...</p>}
-      {tree && <FileTree node={tree} />}
-    </div>
-  );
+    );
+  }
+
+  if (screen === "explorer") {
+    const relative = selected && tree ? selected.replace(tree.path + "/", "") : null;
+    return (
+      <div className="flex h-screen">
+        <div className="w-64 border-r p-2 flex flex-col">
+          <Button variant="outline" size="sm" className="mb-2" onClick={() => setScreen("home")}>Back</Button>
+          <Input
+            placeholder="Search..."
+            value={filter}
+            onChange={(e) => setFilter(e.target.value)}
+            className="mb-2"
+          />
+          {loading && <p className="text-sm">Cloning...</p>}
+          {tree && <FileTree node={tree} selected={selected} onSelect={setSelected} filter={filter} />}
+        </div>
+        <div className="flex-1 p-4 overflow-auto">
+          {selected ? (
+            <>
+              <div className="text-sm text-muted-foreground mb-2">{relative}</div>
+              <FileViewer path={selected} />
+            </>
+          ) : (
+            <p className="text-sm text-muted-foreground">Select a file to view</p>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  return <div />;
 }
+

--- a/packages/code-explorer/src/components/ActionCard.tsx
+++ b/packages/code-explorer/src/components/ActionCard.tsx
@@ -1,0 +1,29 @@
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import type { LucideIcon } from "lucide-react";
+
+interface ActionCardProps {
+  icon: LucideIcon;
+  title: string;
+  description: string;
+  cta: string;
+  onClick: () => void;
+}
+
+export function ActionCard({ icon: Icon, title, description, cta, onClick }: ActionCardProps) {
+  return (
+    <Card className="w-full max-w-sm transition-shadow hover:shadow-md">
+      <CardHeader className="text-center">
+        <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-gradient-to-br from-purple-500 to-indigo-500 text-white">
+          <Icon className="h-6 w-6" />
+        </div>
+        <CardTitle className="text-lg">{title}</CardTitle>
+        <CardDescription className="text-sm text-muted-foreground">{description}</CardDescription>
+      </CardHeader>
+      <CardContent className="flex justify-center">
+        <Button onClick={onClick}>{cta}</Button>
+      </CardContent>
+    </Card>
+  );
+}
+

--- a/packages/code-explorer/src/components/FileTree.tsx
+++ b/packages/code-explorer/src/components/FileTree.tsx
@@ -1,0 +1,78 @@
+import React, { useState } from "react";
+import { ChevronRight, ChevronDown, Folder, FileText } from "lucide-react";
+import clsx from "clsx";
+
+export interface TreeNode {
+  name: string;
+  path: string;
+  children?: TreeNode[];
+}
+
+interface FileTreeProps {
+  node: TreeNode;
+  selected?: string | null;
+  onSelect: (path: string) => void;
+  filter: string;
+}
+
+function matchesFilter(node: TreeNode, filter: string): boolean {
+  if (!filter) return true;
+  const lower = filter.toLowerCase();
+  if (node.name.toLowerCase().includes(lower)) return true;
+  return node.children?.some((c) => matchesFilter(c, filter)) ?? false;
+}
+
+function fileColor(name: string): string {
+  if (/\.(ts|tsx|js|jsx)$/.test(name)) return "text-blue-500";
+  if (/\.json$/.test(name)) return "text-green-500";
+  if (/\.css$/.test(name)) return "text-purple-500";
+  return "";
+}
+
+export function FileTree({ node, selected, onSelect, filter }: FileTreeProps) {
+  const [open, setOpen] = useState(true);
+  const isDir = !!node.children;
+  if (!matchesFilter(node, filter)) return null;
+  return (
+    <div className="ml-2">
+      <div
+        className={clsx(
+          "flex items-center cursor-pointer py-0.5",
+          selected === node.path && "bg-accent text-accent-foreground"
+        )}
+        onClick={() => {
+          if (isDir) setOpen((o) => !o);
+          else onSelect(node.path);
+        }}
+      >
+        {isDir ? (
+          open ? (
+            <ChevronDown className="mr-1 h-4 w-4" />
+          ) : (
+            <ChevronRight className="mr-1 h-4 w-4" />
+          )
+        ) : (
+          <FileText className={clsx("mr-1 h-4 w-4", fileColor(node.name))} />
+        )}
+        {isDir && <Folder className="mr-1 h-4 w-4" />}
+        <span className={clsx(isDir ? "font-semibold" : fileColor(node.name))}>
+          {node.name}
+        </span>
+      </div>
+      {isDir && open && (
+        <div className="ml-4">
+          {node.children?.map((child) => (
+            <FileTree
+              key={child.path}
+              node={child}
+              selected={selected}
+              onSelect={onSelect}
+              filter={filter}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/packages/code-explorer/src/components/FileViewer.tsx
+++ b/packages/code-explorer/src/components/FileViewer.tsx
@@ -1,0 +1,57 @@
+import React, { useEffect, useState } from "react";
+import Prism from "prismjs";
+import "prismjs/components/prism-typescript";
+import "prismjs/components/prism-javascript";
+import { Button } from "@/components/ui/button";
+
+interface Props {
+  path: string;
+}
+
+export function FileViewer({ path }: Props) {
+  const [code, setCode] = useState("");
+  const [fullscreen, setFullscreen] = useState(false);
+
+  useEffect(() => {
+    async function load() {
+      const res = await fetch(`/explorer/api/file?path=${encodeURIComponent(path)}`);
+      const text = await res.text();
+      setCode(text);
+    }
+    if (path) load();
+  }, [path]);
+
+  useEffect(() => {
+    Prism.highlightAll();
+  }, [code]);
+
+  const lines = code.split("\n");
+
+  return (
+    <div className={fullscreen ? "fixed inset-4 bg-background z-50 p-4" : "relative"}>
+      <div className="mb-2 flex gap-2 justify-end">
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={() => navigator.clipboard.writeText(code)}
+        >
+          Copy
+        </Button>
+        <Button size="sm" variant="outline" onClick={() => setFullscreen((f) => !f)}>
+          {fullscreen ? "Exit" : "Full screen"}
+        </Button>
+      </div>
+      <div className="overflow-auto h-full border rounded">
+        <pre className="language-tsx text-sm flex">
+          <code className="text-right pr-4 select-none border-r">
+            {lines.map((_, i) => (
+              <div key={i}>{i + 1}</div>
+            ))}
+          </code>
+          <code className="pl-4" dangerouslySetInnerHTML={{ __html: Prism.highlight(code, Prism.languages.tsx, "tsx") }} />
+        </pre>
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- implement searchable, color-coded file tree with collapsible directories
- add syntax-highlighted code viewer with line numbers, copy, and full-screen modes
- integrate new components into explorer layout with file search and path breadcrumb

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b90e8fbbd48331ad8d5d4252e353cb