### PR TITLE
feat: add isolated dev env for code explorer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,22 @@
 # Mining Syndicate Platform
 
+## Development
+
+- **Full application**: `npm run dev`
+  - Starts the Express API and Vite client.
+  - Visit `http://localhost:5000` to view the site.
+- **Isolated Code Explorer**: `npm run dev:explorer`
+  - Launches only the Code Explorer module at `http://localhost:5000/explorer`.
+  - Uses the same React, Tailwind and UI components as the main app.
+  - Requires `git` and network access to import public repositories.
+
+No additional environment variables are required; the server listens on `PORT` if set (defaults to `5000`).
+
 ## Self-Contained Tools
 
 This repository includes optional tools that run separately from the main application.
 
- - **Card Builder**: `npm run card-builder` starts a local drag-and-drop card editor at http://localhost:3100. See [Card Builder – Use Case and Requirements](docs/card-builder-use-case-requirements.md) for details on the MVP.
-- **Code Explorer**: `npm run code-explorer <target-directory>` indexes a directory and serves a visual explorer at http://localhost:3200.
+- **Card Builder**: `npm run card-builder` starts a local drag-and-drop card editor at `http://localhost:3100`. See [Card Builder – Use Case and Requirements](docs/card-builder-use-case-requirements.md) for details on the MVP.
+- **Code Explorer**: `npm run dev:explorer` as noted above.
 
 These tools are standalone and do not affect production or the main development server.

--- a/client/src/explorer/index.tsx
+++ b/client/src/explorer/index.tsx
@@ -1,0 +1,5 @@
+import { createRoot } from "react-dom/client";
+import { CodeExplorerApp } from "../../../packages/code-explorer";
+import "@/index.css";
+
+createRoot(document.getElementById("root")!).render(<CodeExplorerApp />);

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "scripts": {
     "dev": "NODE_ENV=development tsx server/index.ts",
+    "dev:explorer": "NODE_ENV=development tsx server/explorer.ts",
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",

--- a/packages/code-explorer/src/index.tsx
+++ b/packages/code-explorer/src/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
 import { CodeExplorerApp } from "./App";
+import "@/index.css";
 
 const root = createRoot(document.getElementById("root")!);
 root.render(<CodeExplorerApp />);

--- a/server/explorer.ts
+++ b/server/explorer.ts
@@ -1,0 +1,60 @@
+import express from "express";
+import { createServer } from "http";
+import path from "path";
+import fs from "fs";
+import os from "os";
+import { promisify } from "util";
+import { exec as execCb } from "child_process";
+import { nanoid } from "nanoid";
+import { setupViteFor, log } from "./vite";
+import { buildFileTree } from "../packages/code-explorer/file-tree.js";
+
+const exec = promisify(execCb);
+
+const app = express();
+app.use(express.json());
+
+let currentRepoDir: string | null = null;
+
+app.post("/explorer/api/clone", async (req, res) => {
+  try {
+    const repo: string = req.body.repo;
+    if (!repo) {
+      return res.status(400).json({ error: "repo is required" });
+    }
+    const baseDir = path.join(os.tmpdir(), "explorer", nanoid());
+    await fs.promises.mkdir(baseDir, { recursive: true });
+    await exec(`git clone --depth=1 ${repo} ${baseDir}`);
+    currentRepoDir = baseDir;
+    const tree = buildFileTree(baseDir);
+    res.json(tree);
+  } catch (err: any) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.get("/explorer/api/file", async (req, res) => {
+  const filePath = req.query.path as string | undefined;
+  try {
+    if (!filePath || (currentRepoDir && !filePath.startsWith(currentRepoDir))) {
+      return res.status(400).send("Invalid path");
+    }
+    const data = await fs.promises.readFile(filePath, "utf8");
+    res.type("text/plain").send(data);
+  } catch (err: any) {
+    res.status(500).send(err.message);
+  }
+});
+
+const server = createServer(app);
+
+(async () => {
+  const rootDir = path.resolve(import.meta.dirname, "..", "packages", "code-explorer");
+  await setupViteFor(app, server, rootDir, "/explorer");
+
+  const port = parseInt(process.env.PORT || "5000", 10);
+  server.listen({ port, host: "0.0.0.0", reusePort: true }, () => {
+    log(`explorer dev server running on port ${port}`);
+  });
+})();
+

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -2,7 +2,12 @@ import type { Config } from "tailwindcss";
 
 export default {
   darkMode: ["class"],
-  content: ["./client/index.html", "./client/src/**/*.{js,jsx,ts,tsx}"],
+  content: [
+    "./client/index.html",
+    "./client/src/**/*.{js,jsx,ts,tsx}",
+    "./packages/code-explorer/index.html",
+    "./packages/code-explorer/src/**/*.{js,jsx,ts,tsx}",
+  ],
   theme: {
     extend: {
       borderRadius: {


### PR DESCRIPTION
## Summary
- add `npm run dev:explorer` to spin up standalone Code Explorer
- wire Express server for explorer with clone and file APIs
- document separate explorer workflow in README

## Testing
- `npm test`
- `npm run build`
- `npm run dev:explorer` (curl `/explorer/`)
- `curl -X POST /explorer/api/clone`
- `curl /explorer/api/file?path=...`


------
https://chatgpt.com/codex/tasks/task_e_68b9dbaf87308331a095e44a7d6df313