### PR TITLE
Serve Code Explorer dev environment under /code-explorer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,22 @@
 # Mining Syndicate Platform
 
+## Development
+
+- **Full application**: `npm run dev`
+  - Starts the Express API and Vite client.
+  - Visit `http://localhost:5000` to view the site.
+- **Isolated Code Explorer**: `npm run dev:explorer`
+  - Launches only the Code Explorer module at `http://localhost:5000/code-explorer`.
+  - Uses the same React, Tailwind and UI components as the main app.
+  - Requires `git` and network access to import public repositories.
+
+No additional environment variables are required; the server listens on `PORT` if set (defaults to `5000`).
+
 ## Self-Contained Tools
 
 This repository includes optional tools that run separately from the main application.
 
- - **Card Builder**: `npm run card-builder` starts a local drag-and-drop card editor at http://localhost:3100. See [Card Builder – Use Case and Requirements](docs/card-builder-use-case-requirements.md) for details on the MVP.
-- **Code Explorer**: `npm run code-explorer <target-directory>` indexes a directory and serves a visual explorer at http://localhost:3200.
+- **Card Builder**: `npm run card-builder` starts a local drag-and-drop card editor at `http://localhost:3100`. See [Card Builder – Use Case and Requirements](docs/card-builder-use-case-requirements.md) for details on the MVP.
+- **Code Explorer**: `npm run dev:explorer` as noted above. A mock repository based on the local code-explorer package is served for testing.
 
 These tools are standalone and do not affect production or the main development server.

--- a/client/src/explorer/index.tsx
+++ b/client/src/explorer/index.tsx
@@ -1,0 +1,5 @@
+import { createRoot } from "react-dom/client";
+import { CodeExplorerApp } from "../../../packages/code-explorer";
+import "@/index.css";
+
+createRoot(document.getElementById("root")!).render(<CodeExplorerApp />);

--- a/package-lock.json
+++ b/package-lock.json
@@ -109,6 +109,7 @@
         "drizzle-kit": "^0.30.4",
         "esbuild": "^0.25.0",
         "jsdom": "^24.0.0",
+        "open": "^10.2.0",
         "postcss": "^8.4.47",
         "tailwindcss": "^3.4.17",
         "tsx": "^4.19.1",
@@ -4660,6 +4661,22 @@
         "node": ">=6.14.2"
       }
     },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -5367,6 +5384,36 @@
         "node": ">=6"
       }
     },
+    "node_modules/default-browser": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.2.1.tgz",
+      "integrity": "sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.0.tgz",
+      "integrity": "sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/define-data-property": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
@@ -5382,6 +5429,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/delayed-stream": {
@@ -7288,6 +7348,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -7316,6 +7392,25 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-number": {
@@ -7347,6 +7442,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
+      "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -8400,6 +8511,25 @@
       },
       "engines": {
         "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "wsl-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -9641,6 +9771,19 @@
       "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/run-applescript": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.0.0.tgz",
+      "integrity": "sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
@@ -11955,6 +12098,22 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/xlsx": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "scripts": {
     "dev": "NODE_ENV=development tsx server/index.ts",
+    "dev:explorer": "NODE_ENV=development tsx server/explorer.ts",
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
@@ -112,6 +113,7 @@
     "drizzle-kit": "^0.30.4",
     "esbuild": "^0.25.0",
     "jsdom": "^24.0.0",
+    "open": "^10.2.0",
     "postcss": "^8.4.47",
     "tailwindcss": "^3.4.17",
     "tsx": "^4.19.1",

--- a/packages/code-explorer/src/App.tsx
+++ b/packages/code-explorer/src/App.tsx
@@ -26,7 +26,7 @@ export function CodeExplorerApp() {
 
   async function handleScan(repo: string) {
     setLoading(true);
-    const res = await fetch("/explorer/api/clone", {
+    const res = await fetch("/code-explorer/api/clone", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ repo }),

--- a/packages/code-explorer/src/components/FileViewer.tsx
+++ b/packages/code-explorer/src/components/FileViewer.tsx
@@ -14,7 +14,7 @@ export function FileViewer({ path }: Props) {
 
   useEffect(() => {
     async function load() {
-      const res = await fetch(`/explorer/api/file?path=${encodeURIComponent(path)}`);
+      const res = await fetch(`/code-explorer/api/file?path=${encodeURIComponent(path)}`);
       const text = await res.text();
       setCode(text);
     }

--- a/packages/code-explorer/src/index.tsx
+++ b/packages/code-explorer/src/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
 import { CodeExplorerApp } from "./App";
+import "@/index.css";
 
 const root = createRoot(document.getElementById("root")!);
 root.render(<CodeExplorerApp />);

--- a/server/explorer.ts
+++ b/server/explorer.ts
@@ -1,0 +1,64 @@
+import express from "express";
+import { createServer } from "http";
+import path from "path";
+import fs from "fs";
+import os from "os";
+import { promisify } from "util";
+import { exec as execCb } from "child_process";
+import { nanoid } from "nanoid";
+import open from "open";
+import { setupViteFor, log } from "./vite";
+import { buildFileTree } from "../packages/code-explorer/file-tree.js";
+
+const exec = promisify(execCb);
+
+const app = express();
+app.use(express.json());
+
+let currentRepoDir: string | null = null;
+
+app.post("/code-explorer/api/clone", async (req, res) => {
+  try {
+    const repo: string = req.body.repo;
+    if (!repo) {
+      return res.status(400).json({ error: "repo is required" });
+    }
+    const baseDir = path.join(os.tmpdir(), "explorer", nanoid());
+    await fs.promises.mkdir(baseDir, { recursive: true });
+    await exec(`git clone --depth=1 ${repo} ${baseDir}`);
+    currentRepoDir = baseDir;
+    const tree = buildFileTree(baseDir);
+    res.json(tree);
+  } catch (err: any) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.get("/code-explorer/api/file", async (req, res) => {
+  const filePath = req.query.path as string | undefined;
+  try {
+    if (!filePath || (currentRepoDir && !filePath.startsWith(currentRepoDir))) {
+      return res.status(400).send("Invalid path");
+    }
+    const data = await fs.promises.readFile(filePath, "utf8");
+    res.type("text/plain").send(data);
+  } catch (err: any) {
+    res.status(500).send(err.message);
+  }
+});
+
+const server = createServer(app);
+
+(async () => {
+  const rootDir = path.resolve(import.meta.dirname, "..", "packages", "code-explorer");
+  await setupViteFor(app, server, rootDir, "/code-explorer");
+
+  const port = parseInt(process.env.PORT || "5000", 10);
+  server.listen({ port, host: "0.0.0.0", reusePort: true }, () => {
+    log(`explorer dev server running on port ${port}`);
+    void open(`http://localhost:${port}/code-explorer`, { wait: false }).catch(
+      () => {},
+    );
+  });
+})();
+

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -101,12 +101,13 @@ export async function setupViteFor(
     ...viteConfig,
     configFile: false,
     root: rootDir,
+    base: route,
     server: serverOptions,
     appType: "custom",
   });
 
   app.use(route, vite.middlewares);
-  app.use(`${route}/*`, async (req, res, next) => {
+  app.use(route, async (req, res, next) => {
     try {
       const url = req.originalUrl.replace(route, "");
       const templatePath = path.resolve(rootDir, "index.html");

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -2,7 +2,12 @@ import type { Config } from "tailwindcss";
 
 export default {
   darkMode: ["class"],
-  content: ["./client/index.html", "./client/src/**/*.{js,jsx,ts,tsx}"],
+  content: [
+    "./client/index.html",
+    "./client/src/**/*.{js,jsx,ts,tsx}",
+    "./packages/code-explorer/index.html",
+    "./packages/code-explorer/src/**/*.{js,jsx,ts,tsx}",
+  ],
   theme: {
     extend: {
       borderRadius: {


### PR DESCRIPTION
## Summary
- Serve the Explorer dev server at `/code-explorer` and open the browser automatically
- Configure Vite's middleware with a route base and direct HTML handler so assets resolve under `/code-explorer`
- Update Code Explorer client fetches and README instructions to the new `/code-explorer` path

## Testing
- `npm test`
- `npm run dev:explorer`

------
https://chatgpt.com/codex/tasks/task_e_68b9dbaf87308331a095e44a7d6df313