### PR TITLE
feat: enable cross-platform explorer dev env

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,17 +3,19 @@
 ## Development
 
 - **Full application**: `npm run dev`
-  - Starts the Express API and Vite client.
+  - Starts the Express API and Vite client with `NODE_ENV=development` via [cross-env](https://www.npmjs.com/package/cross-env) for cross‑platform compatibility.
   - Visit `http://localhost:5000` to view the site.
 - **Isolated Code Explorer**: `npm run dev:explorer`
-
   - Launches only the Code Explorer module at `http://localhost:5000/code-explorer`.
-  - Uses the same React, Tailwind and UI components as the main app.
+  - Shares React, Tailwind and all Shadcn UI components with the main app.
   - Requires `git` and network access to import public repositories.
   - Automatically opens your browser to the explorer page.
 
+Assumptions/Env vars:
 
-No additional environment variables are required; the server listens on `PORT` if set (defaults to `5000`).
+- `PORT` (optional) – port for both servers (defaults to `5000`).
+- `git` must be available in your PATH for repository cloning.
+- No other environment variables are required for local development.
 
 ## Self-Contained Tools
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -106,6 +106,7 @@
         "@types/ws": "^8.5.13",
         "@vitejs/plugin-react": "^4.3.2",
         "autoprefixer": "^10.4.20",
+        "cross-env": "^10.0.0",
         "drizzle-kit": "^0.30.4",
         "esbuild": "^0.25.0",
         "jsdom": "^24.0.0",
@@ -620,6 +621,13 @@
       "integrity": "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/@epic-web/invariant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@esbuild-kit/core-utils": {
       "version": "3.3.2",
@@ -5083,6 +5091,24 @@
       },
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.0.0.tgz",
+      "integrity": "sha512-aU8qlEK/nHYtVuN4p7UQgAwVljzMg8hB4YK5ThRqD2l/ziSnryncPNn7bMLt5cFYsKVKBh8HqLqyCoTupEUu7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@epic-web/invariant": "^1.0.0",
+        "cross-spawn": "^7.0.6"
+      },
+      "bin": {
+        "cross-env": "dist/bin/cross-env.js",
+        "cross-env-shell": "dist/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "type": "module",
   "license": "MIT",
   "scripts": {
-    "dev": "NODE_ENV=development tsx server/index.ts",
-    "dev:explorer": "NODE_ENV=development tsx server/explorer.ts",
+    "dev": "cross-env NODE_ENV=development tsx server/index.ts",
+    "dev:explorer": "cross-env NODE_ENV=development tsx server/explorer.ts",
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
-    "start": "NODE_ENV=production node dist/index.js",
+    "start": "cross-env NODE_ENV=production node dist/index.js",
     "check": "tsc",
     "test": "vitest run",
     "db:push": "drizzle-kit push"
@@ -110,6 +110,7 @@
     "@types/ws": "^8.5.13",
     "@vitejs/plugin-react": "^4.3.2",
     "autoprefixer": "^10.4.20",
+    "cross-env": "^10.0.0",
     "drizzle-kit": "^0.30.4",
     "esbuild": "^0.25.0",
     "jsdom": "^24.0.0",

--- a/packages/code-explorer/file-tree.js
+++ b/packages/code-explorer/file-tree.js
@@ -1,6 +1,13 @@
 import fs from 'fs';
 import path from 'path';
 
+/**
+ * Type: Recursive utility function
+ * Location: packages/code-explorer/file-tree.js > buildFileTree
+ * Description: Builds an object representing the directory structure of a path.
+ * Notes: Skips .git and node_modules folders during traversal.
+ * EditCounter: 1
+ */
 export function buildFileTree(dir) {
   const name = path.basename(dir);
   const item = { name, path: dir };

--- a/packages/code-explorer/scan.js
+++ b/packages/code-explorer/scan.js
@@ -2,6 +2,13 @@ import fs from 'fs';
 import path from 'path';
 import ts from 'typescript';
 
+/**
+ * Type: Recursive utility function
+ * Location: packages/code-explorer/scan.js > collectFiles
+ * Description: Traverses directories to gather source files with JS/TS extensions.
+ * Notes: Skips node_modules and hidden folders.
+ * EditCounter: 1
+ */
 function collectFiles(dir, files = []) {
   for (const entry of fs.readdirSync(dir)) {
     const full = path.join(dir, entry);
@@ -16,6 +23,13 @@ function collectFiles(dir, files = []) {
   return files;
 }
 
+/**
+ * Type: Parser function
+ * Location: packages/code-explorer/scan.js > parseFile
+ * Description: Parses a source file to extract declared function signatures.
+ * Notes: Utilizes the TypeScript compiler API for analysis.
+ * EditCounter: 1
+ */
 function parseFile(file) {
   const sourceText = fs.readFileSync(file, 'utf8');
   const sourceFile = ts.createSourceFile(file, sourceText, ts.ScriptTarget.Latest, true);
@@ -34,6 +48,13 @@ function parseFile(file) {
   return { file, functions };
 }
 
+/**
+ * Type: Utility function
+ * Location: packages/code-explorer/scan.js > scan
+ * Description: Produces parsed function data for all source files in a directory.
+ * Notes: Combines collectFiles and parseFile helpers.
+ * EditCounter: 1
+ */
 export function scan(dir) {
   const files = collectFiles(dir);
   return files.map(parseFile);

--- a/packages/code-explorer/src/App.tsx
+++ b/packages/code-explorer/src/App.tsx
@@ -14,6 +14,13 @@ import {
 import { FileTree, TreeNode } from "./components/FileTree";
 import { FileViewer } from "./components/FileViewer";
 
+/**
+ * Type: React component
+ * Location: packages/code-explorer/src/App.tsx > CodeExplorerApp
+ * Description: Entry component for the Code Explorer, managing home and explorer screens.
+ * Notes: Maintains UI state for repository scanning and file viewing.
+ * EditCounter: 1
+ */
 export function CodeExplorerApp() {
   const [screen, setScreen] = useState<"home" | "explorer">("home");
   const [tree, setTree] = useState<TreeNode | null>(null);
@@ -24,6 +31,13 @@ export function CodeExplorerApp() {
   const [selected, setSelected] = useState<string | null>(null);
   const [filter, setFilter] = useState("");
 
+  /**
+   * Type: Async function
+   * Location: packages/code-explorer/src/App.tsx > CodeExplorerApp > handleScan
+   * Description: Calls backend to clone the repo and build the file tree, then switches to explorer view.
+   * Notes: Updates loading state while request is in flight.
+   * EditCounter: 1
+   */
   async function handleScan(repo: string) {
     setLoading(true);
     const res = await fetch("/code-explorer/api/clone", {
@@ -37,6 +51,13 @@ export function CodeExplorerApp() {
     setScreen("explorer");
   }
 
+  /**
+   * Type: Function
+   * Location: packages/code-explorer/src/App.tsx > CodeExplorerApp > handleImport
+   * Description: Validates user-entered GitHub URL and triggers repository scan.
+   * Notes: Displays error message for invalid URLs.
+   * EditCounter: 1
+   */
   function handleImport() {
     if (!/^https:\/\/github.com\/.+/.test(repoUrl)) {
       setError("Please enter a valid GitHub URL");

--- a/packages/code-explorer/src/components/ActionCard.tsx
+++ b/packages/code-explorer/src/components/ActionCard.tsx
@@ -10,6 +10,13 @@ interface ActionCardProps {
   onClick: () => void;
 }
 
+/**
+ * Type: React component
+ * Location: packages/code-explorer/src/components/ActionCard.tsx > ActionCard
+ * Description: Displays a clickable card used on the explorer landing page.
+ * Notes: Renders provided icon, title and call-to-action button.
+ * EditCounter: 1
+ */
 export function ActionCard({ icon: Icon, title, description, cta, onClick }: ActionCardProps) {
   return (
     <Card className="w-full max-w-sm transition-shadow hover:shadow-md">

--- a/packages/code-explorer/src/components/FileTree.tsx
+++ b/packages/code-explorer/src/components/FileTree.tsx
@@ -15,6 +15,13 @@ interface FileTreeProps {
   filter: string;
 }
 
+/**
+ * Type: Helper function
+ * Location: packages/code-explorer/src/components/FileTree.tsx > matchesFilter
+ * Description: Checks if a tree node or its descendants match the search filter.
+ * Notes: Recursively examines child nodes.
+ * EditCounter: 1
+ */
 function matchesFilter(node: TreeNode, filter: string): boolean {
   if (!filter) return true;
   const lower = filter.toLowerCase();
@@ -22,6 +29,13 @@ function matchesFilter(node: TreeNode, filter: string): boolean {
   return node.children?.some((c) => matchesFilter(c, filter)) ?? false;
 }
 
+/**
+ * Type: Helper function
+ * Location: packages/code-explorer/src/components/FileTree.tsx > fileColor
+ * Description: Returns a Tailwind text color class based on file extension.
+ * Notes: Used for syntax-aware coloring in the tree.
+ * EditCounter: 1
+ */
 function fileColor(name: string): string {
   if (/\.(ts|tsx|js|jsx)$/.test(name)) return "text-blue-500";
   if (/\.json$/.test(name)) return "text-green-500";
@@ -29,6 +43,13 @@ function fileColor(name: string): string {
   return "";
 }
 
+/**
+ * Type: React component
+ * Location: packages/code-explorer/src/components/FileTree.tsx > FileTree
+ * Description: Renders a collapsible file tree with selectable nodes.
+ * Notes: Highlights selected path and applies search filtering.
+ * EditCounter: 1
+ */
 export function FileTree({ node, selected, onSelect, filter }: FileTreeProps) {
   const [open, setOpen] = useState(true);
   const isDir = !!node.children;

--- a/packages/code-explorer/src/components/FileViewer.tsx
+++ b/packages/code-explorer/src/components/FileViewer.tsx
@@ -8,11 +8,25 @@ interface Props {
   path: string;
 }
 
+/**
+ * Type: React component
+ * Location: packages/code-explorer/src/components/FileViewer.tsx > FileViewer
+ * Description: Fetches and displays highlighted source code with line numbers.
+ * Notes: Provides copy and fullscreen controls for the current file.
+ * EditCounter: 1
+ */
 export function FileViewer({ path }: Props) {
   const [code, setCode] = useState("");
   const [fullscreen, setFullscreen] = useState(false);
 
   useEffect(() => {
+    /**
+     * Type: Async helper function
+     * Location: packages/code-explorer/src/components/FileViewer.tsx > useEffect load
+     * Description: Retrieves file contents from the backend for the specified path.
+     * Notes: Updates local state once the content is loaded.
+     * EditCounter: 1
+     */
     async function load() {
       const res = await fetch(`/code-explorer/api/file?path=${encodeURIComponent(path)}`);
       const text = await res.text();

--- a/server/explorer.ts
+++ b/server/explorer.ts
@@ -17,8 +17,14 @@ app.use(express.json());
 
 let currentRepoDir: string | null = null;
 
+/**
+ * Type: Express route handler
+ * Location: server/explorer.ts > POST /code-explorer/api/clone
+ * Description: Clones a GitHub repository to a temp directory and returns its file tree.
+ * Notes: Updates currentRepoDir for subsequent file fetches.
+ * EditCounter: 1
+ */
 app.post("/code-explorer/api/clone", async (req, res) => {
-
   try {
     const repo: string = req.body.repo;
     if (!repo) {
@@ -35,8 +41,14 @@ app.post("/code-explorer/api/clone", async (req, res) => {
   }
 });
 
+/**
+ * Type: Express route handler
+ * Location: server/explorer.ts > GET /code-explorer/api/file
+ * Description: Reads and returns the contents of a file within the cloned repository.
+ * Notes: Validates that requested path resides in the current repository.
+ * EditCounter: 1
+ */
 app.get("/code-explorer/api/file", async (req, res) => {
-
   const filePath = req.query.path as string | undefined;
   try {
     if (!filePath || (currentRepoDir && !filePath.startsWith(currentRepoDir))) {
@@ -51,10 +63,16 @@ app.get("/code-explorer/api/file", async (req, res) => {
 
 const server = createServer(app);
 
+/**
+ * Type: Async IIFE
+ * Location: server/explorer.ts > server startup
+ * Description: Configures Vite middleware and starts the explorer development server.
+ * Notes: Automatically opens the explorer URL in the default browser.
+ * EditCounter: 1
+ */
 (async () => {
   const rootDir = path.resolve(import.meta.dirname, "..", "packages", "code-explorer");
   await setupViteFor(app, server, rootDir, "/code-explorer");
-
 
   const port = parseInt(process.env.PORT || "5000", 10);
   server.listen({ port, host: "0.0.0.0", reusePort: true }, () => {
@@ -62,7 +80,6 @@ const server = createServer(app);
     void open(`http://localhost:${port}/code-explorer`, { wait: false }).catch(
       () => {},
     );
-
   });
 })();
 


### PR DESCRIPTION
## Summary
- use cross-env in npm scripts for Windows compatibility
- document explorer and full app dev modes
- add detailed comments with edit counters across Code Explorer functions

## Testing
- `npm test`
- `npm run check` *(fails: Cannot find name 'siteAccessControl' and other TS errors)*
- `npm run dev:explorer` *(started, verified repository clone and file fetch via curl)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f93d96e883319c1a4da032c8a90e