### PR TITLE
feat(code-explorer): notify import progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,10 @@ This repository includes optional tools that run separately from the main applic
 - **Code Explorer**: `npm run dev:explorer` as noted above. A mock repository based on the local code-explorer package is served for testing.
 
 These tools are standalone and do not affect production or the main development server.
+
+## Testing
+
+- Run all unit and integration tests with `npm test`.
+- To interact with the Code Explorer during development, start it via `npm run dev:explorer`.
+
+Both commands work in standard Node environments and on Replit.

--- a/packages/code-explorer/src/App.tsx
+++ b/packages/code-explorer/src/App.tsx
@@ -15,12 +15,15 @@ import { FileTree, TreeNode } from "./components/FileTree";
 import { FileViewer } from "./components/FileViewer";
 
 /**
- * Type: React component
- * Location: packages/code-explorer/src/App.tsx > CodeExplorerApp
- * Description: Entry component for the Code Explorer, managing home and explorer screens.
- * Notes: Maintains UI state for repository scanning and file viewing.
- * EditCounter: 1
- */
+{
+  "friendlyName": "Code Explorer App",
+  "description": "Entry component for the Code Explorer, managing home and explorer screens.",
+  "editCount": 2,
+  "tags": ["ui", "app"],
+  "location": "src/App",
+  "notes": "Maintains UI state for repository scanning and file viewing."
+}
+*/
 export function CodeExplorerApp() {
   const [screen, setScreen] = useState<"home" | "explorer">("home");
   const [tree, setTree] = useState<TreeNode | null>(null);
@@ -30,34 +33,49 @@ export function CodeExplorerApp() {
   const [error, setError] = useState("");
   const [selected, setSelected] = useState<string | null>(null);
   const [filter, setFilter] = useState("");
+  const [status, setStatus] = useState("");
 
   /**
-   * Type: Async function
-   * Location: packages/code-explorer/src/App.tsx > CodeExplorerApp > handleScan
-   * Description: Calls backend to clone the repo and build the file tree, then switches to explorer view.
-   * Notes: Updates loading state while request is in flight.
-   * EditCounter: 1
-   */
+  {
+    "friendlyName": "handle repository scan",
+    "description": "Clones the repository and builds the file tree before switching to explorer view.",
+    "editCount": 2,
+    "tags": ["data", "repo"],
+    "location": "src/App > handleScan",
+    "notes": "Sets status messages for import progress and handles failure states."
+  }
+  */
   async function handleScan(repo: string) {
+    setStatus("Import started");
     setLoading(true);
-    const res = await fetch("/code-explorer/api/clone", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ repo }),
-    });
-    const data = await res.json();
-    setTree(data);
-    setLoading(false);
-    setScreen("explorer");
+    try {
+      const res = await fetch("/code-explorer/api/clone", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ repo }),
+      });
+      if (!res.ok) throw new Error("clone failed");
+      const data = await res.json();
+      setTree(data);
+      setStatus("");
+      setScreen("explorer");
+    } catch {
+      setStatus("Import failed");
+    } finally {
+      setLoading(false);
+    }
   }
 
   /**
-   * Type: Function
-   * Location: packages/code-explorer/src/App.tsx > CodeExplorerApp > handleImport
-   * Description: Validates user-entered GitHub URL and triggers repository scan.
-   * Notes: Displays error message for invalid URLs.
-   * EditCounter: 1
-   */
+  {
+    "friendlyName": "handle import action",
+    "description": "Validates user-entered GitHub URL and triggers repository scan.",
+    "editCount": 2,
+    "tags": ["user-input", "repo"],
+    "location": "src/App > handleImport",
+    "notes": "Closes the dialog and clears previous errors before scanning."
+  }
+  */
   function handleImport() {
     if (!/^https:\/\/github.com\/.+/.test(repoUrl)) {
       setError("Please enter a valid GitHub URL");
@@ -70,7 +88,7 @@ export function CodeExplorerApp() {
 
   if (screen === "home") {
     return (
-      <div className="p-6 flex justify-center">
+      <div className="p-6 flex flex-col items-center">
         <div className="grid gap-6 md:grid-cols-3">
           <ActionCard
             icon={Folder}
@@ -97,6 +115,11 @@ export function CodeExplorerApp() {
             }}
           />
         </div>
+        {status && (
+          <p className={`mt-4 text-sm ${status.includes("failed") ? "text-red-500" : ""}`}>
+            {status}
+          </p>
+        )}
         <Dialog open={showImport} onOpenChange={setShowImport}>
           <DialogContent>
             <DialogHeader>

--- a/packages/code-explorer/src/import-flow.test.tsx
+++ b/packages/code-explorer/src/import-flow.test.tsx
@@ -1,0 +1,91 @@
+/* @vitest-environment jsdom */
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { vi, beforeEach, afterEach, describe, it, expect } from "vitest";
+import { CodeExplorerApp } from "./App";
+
+vi.mock("prismjs", () => ({
+  default: { highlightAll: vi.fn(), highlight: (code: string) => code, languages: { tsx: {} } },
+  highlightAll: vi.fn(),
+  highlight: (code: string) => code,
+  languages: { tsx: {} },
+}));
+vi.mock("prismjs/components/prism-typescript", () => ({}));
+vi.mock("prismjs/components/prism-javascript", () => ({}));
+vi.mock("@/components/ui/button", () => ({
+  Button: (props: any) => <button {...props} />,
+}));
+vi.mock("@/components/ui/input", () => ({
+  Input: (props: any) => <input {...props} />,
+}));
+vi.mock("@/components/ui/dialog", () => ({
+  Dialog: ({ children, open }: any) => (open ? <div>{children}</div> : null),
+  DialogContent: ({ children }: any) => <div>{children}</div>,
+  DialogHeader: ({ children }: any) => <div>{children}</div>,
+  DialogTitle: ({ children }: any) => <div>{children}</div>,
+  DialogDescription: ({ children }: any) => <div>{children}</div>,
+  DialogFooter: ({ children }: any) => <div>{children}</div>,
+}));
+vi.mock("@/components/ui/card", () => ({
+  Card: ({ children }: any) => <div>{children}</div>,
+  CardHeader: ({ children }: any) => <div>{children}</div>,
+  CardTitle: ({ children }: any) => <div>{children}</div>,
+  CardDescription: ({ children }: any) => <div>{children}</div>,
+  CardContent: ({ children }: any) => <div>{children}</div>,
+}));
+
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+});
+
+describe("import workflow", () => {
+  it("notifies on start and loads tree and viewer on success", async () => {
+    const tree = { path: "/repo", name: "repo", children: [{ name: "README.md", path: "/repo/README.md" }] };
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => tree })
+      .mockResolvedValueOnce({ ok: true, text: async () => "file content" });
+    global.fetch = fetchMock as any;
+
+    render(<CodeExplorerApp />);
+
+    fireEvent.click(screen.getAllByText("Import")[0]);
+    fireEvent.change(screen.getByPlaceholderText("https://github.com/user/repo"), {
+      target: { value: "https://github.com/user/repo" },
+    });
+    fireEvent.click(screen.getAllByText("Import")[1]);
+
+    await screen.findByText("Import started");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/code-explorer/api/clone",
+      expect.objectContaining({ method: "POST" })
+    );
+
+    const fileNode = await screen.findByText("README.md");
+    fireEvent.click(fileNode);
+    await screen.findByText("file content");
+  });
+
+  it("shows failure message when clone fails", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false });
+    global.fetch = fetchMock as any;
+
+    render(<CodeExplorerApp />);
+
+    fireEvent.click(screen.getAllByText("Import")[0]);
+    fireEvent.change(screen.getByPlaceholderText("https://github.com/user/repo"), {
+      target: { value: "https://github.com/user/repo" },
+    });
+    fireEvent.click(screen.getAllByText("Import")[1]);
+
+    await screen.findByText("Import started");
+    await screen.findByText("Import failed");
+  });
+});
+


### PR DESCRIPTION
## Summary
- show status messages for repository imports
- load repository tree after successful import and notify on failures
- add integration tests for import workflow
- document `npm test` and `npm run dev:explorer`

## Testing
- `npm test`
- `npx vitest run --root . packages/code-explorer/src/import-flow.test.tsx`
- `npm run dev:explorer`


------
https://chatgpt.com/codex/tasks/task_e_68ba03ad96688331bcd7cb46a55bcd35