### PR TITLE
fix: ensure prism tsx grammar loads in code explorer

### DIFF
--- a/packages/code-explorer/src/components/FileViewer.test.tsx
+++ b/packages/code-explorer/src/components/FileViewer.test.tsx
@@ -1,0 +1,33 @@
+/* @vitest-environment jsdom */
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { FileViewer } from "./FileViewer";
+import Prism from "prismjs";
+
+vi.mock("@/components/ui/button", () => ({
+  Button: (props: any) => <button {...props} />,
+}));
+
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+});
+
+describe("FileViewer", () => {
+  it("renders code even when Prism lacks grammar", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, text: async () => "let x = 1;" });
+    global.fetch = fetchMock as any;
+    vi.spyOn(Prism, "highlight").mockImplementationOnce(() => {
+      throw new Error("missing grammar");
+    });
+
+    render(<FileViewer path="/repo/test.ts" />);
+    await screen.findByText((_, el) => el?.textContent === "let x = 1;");
+  });
+});

--- a/packages/code-explorer/src/components/FileViewer.tsx
+++ b/packages/code-explorer/src/components/FileViewer.tsx
@@ -2,6 +2,8 @@ import React, { useEffect, useState } from "react";
 import Prism from "prismjs";
 import "prismjs/components/prism-typescript";
 import "prismjs/components/prism-javascript";
+import "prismjs/components/prism-jsx";
+import "prismjs/components/prism-tsx";
 import { Button } from "@/components/ui/button";
 
 interface Props {
@@ -9,11 +11,29 @@ interface Props {
 }
 
 /**
+{
+  "friendlyName": "highlight code",
+  "description": "Safely highlights source code using Prism, falling back to plain text on failure.",
+  "editCount": 1,
+  "tags": ["utility", "syntax"],
+  "location": "src/components/FileViewer > highlightCode",
+  "notes": "Prevents runtime crashes when a grammar is missing by catching Prism errors."
+}
+*/
+function highlightCode(code: string): string {
+  try {
+    return Prism.highlight(code, Prism.languages.tsx, "tsx");
+  } catch {
+    return code;
+  }
+}
+
+/**
  * Type: React component
  * Location: packages/code-explorer/src/components/FileViewer.tsx > FileViewer
  * Description: Fetches and displays highlighted source code with line numbers.
  * Notes: Provides copy and fullscreen controls for the current file.
- * EditCounter: 1
+ * EditCounter: 2
  */
 export function FileViewer({ path }: Props) {
   const [code, setCode] = useState("");
@@ -62,7 +82,7 @@ export function FileViewer({ path }: Props) {
               <div key={i}>{i + 1}</div>
             ))}
           </code>
-          <code className="pl-4" dangerouslySetInnerHTML={{ __html: Prism.highlight(code, Prism.languages.tsx, "tsx") }} />
+          <code className="pl-4" dangerouslySetInnerHTML={{ __html: highlightCode(code) }} />
         </pre>
       </div>
     </div>

--- a/packages/code-explorer/src/import-flow.test.tsx
+++ b/packages/code-explorer/src/import-flow.test.tsx
@@ -12,6 +12,8 @@ vi.mock("prismjs", () => ({
 }));
 vi.mock("prismjs/components/prism-typescript", () => ({}));
 vi.mock("prismjs/components/prism-javascript", () => ({}));
+vi.mock("prismjs/components/prism-jsx", () => ({}));
+vi.mock("prismjs/components/prism-tsx", () => ({}));
 vi.mock("@/components/ui/button", () => ({
   Button: (props: any) => <button {...props} />,
 }));


### PR DESCRIPTION
## Summary
- import missing Prism JSX/TSX languages to stop viewer crash
- add safe `highlightCode` helper and test coverage for FileViewer
- extend import flow tests with new Prism mocks

## Testing
- `npm test`
- `npx vitest run src/import-flow.test.tsx src/components/FileViewer.test.tsx --root packages/code-explorer`


------
https://chatgpt.com/codex/tasks/task_e_68ba0eefe3b8833196363f274a009c15