### PR TITLE
Refactor FileViewer to use highlight utility

### DIFF
--- a/packages/code-explorer/src/components/FileViewer.test.tsx
+++ b/packages/code-explorer/src/components/FileViewer.test.tsx
@@ -20,6 +20,19 @@ afterEach(() => {
 });
 
 describe("FileViewer", () => {
+  it("renders fetched code with line numbers", async () => {
+    const source = "const a = 1;\nconsole.log(a);";
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: true, text: async () => source });
+    global.fetch = fetchMock as any;
+
+    const { container } = render(<FileViewer path="/repo/test.ts" />);
+    await screen.findByText((_, node) => node.textContent === source);
+    const lineNumbers = container.querySelectorAll("code.text-right div");
+    expect(lineNumbers.length).toBe(2);
+  });
+
   it("renders code even when Prism lacks grammar", async () => {
     const fetchMock = vi.fn().mockResolvedValue({ ok: true, text: async () => "let x = 1;" });
     global.fetch = fetchMock as any;

--- a/packages/code-explorer/src/components/FileViewer.tsx
+++ b/packages/code-explorer/src/components/FileViewer.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from "react";
-import Prism from "prismjs";
 import { highlightCode } from "../utils/highlight";
 import { Button } from "@/components/ui/button";
 
@@ -8,12 +7,15 @@ interface Props {
 }
 
 /**
- * Type: React component
- * Location: packages/code-explorer/src/components/FileViewer.tsx > FileViewer
- * Description: Fetches and displays highlighted source code with line numbers.
- * Notes: Provides copy and fullscreen controls for the current file.
- * EditCounter: 2
- */
+{
+  "friendlyName": "file viewer",
+  "description": "Fetches and displays highlighted source code with line numbers.",
+  "editCount": 3,
+  "tags": ["ui", "code"],
+  "location": "src/components/FileViewer",
+  "notes": "Provides copy and fullscreen controls for the current file."
+}
+*/
 export function FileViewer({ path }: Props) {
   const [code, setCode] = useState("");
   const [fullscreen, setFullscreen] = useState(false);
@@ -33,10 +35,6 @@ export function FileViewer({ path }: Props) {
     }
     if (path) load();
   }, [path]);
-
-  useEffect(() => {
-    Prism.highlightAll();
-  }, [code]);
 
   const lines = code.split("\n");
 


### PR DESCRIPTION
## Summary
- refactor `FileViewer` to render syntax with `highlightCode` and update metadata
- add tests covering normal rendering and Prism fallback behavior

## Testing
- `npx vitest run packages/code-explorer/src/components/FileViewer.test.tsx --root packages/code-explorer`

------
https://chatgpt.com/codex/tasks/task_e_68ba160f70dc83319080051eb2a7cdc5