### PR TITLE
test: add code-explorer coverage

### DIFF
--- a/packages/code-explorer/__tests__/file-tree.test.ts
+++ b/packages/code-explorer/__tests__/file-tree.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { buildFileTree } from "../file-tree.js";
+import fs from "fs";
+import path from "path";
+import os from "os";
+
+const tmpPrefix = path.join(os.tmpdir(), "file-tree-test-");
+let tmpDir: string;
+
+beforeAll(() => {
+  tmpDir = fs.mkdtempSync(tmpPrefix);
+  fs.mkdirSync(path.join(tmpDir, "sub"));
+  fs.writeFileSync(path.join(tmpDir, "root.txt"), "root");
+  fs.writeFileSync(path.join(tmpDir, "sub", "a.txt"), "hi");
+  fs.mkdirSync(path.join(tmpDir, "node_modules"));
+  fs.writeFileSync(path.join(tmpDir, "node_modules", "ignore.js"), "" );
+});
+
+afterAll(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("buildFileTree", () => {
+  it("includes files and subdirectories and ignores node_modules", () => {
+    const tree = buildFileTree(tmpDir);
+    const names = tree.children?.map((c) => c.name) ?? [];
+    expect(names).toContain("root.txt");
+    expect(names).toContain("sub");
+    expect(names).not.toContain("node_modules");
+    const sub = tree.children?.find((c) => c.name === "sub");
+    expect(sub?.children?.map((c) => c.name)).toContain("a.txt");
+  });
+});

--- a/packages/code-explorer/src/utils/highlight.test.ts
+++ b/packages/code-explorer/src/utils/highlight.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect, vi } from "vitest";
+import Prism from "prismjs";
+import { highlightCode } from "./highlight";
+
+describe("highlightCode", () => {
+  it("returns highlighted HTML when grammar exists", () => {
+    const code = "const a = 1;";
+    const result = highlightCode(code, "tsx");
+    expect(result).toContain("<span");
+  });
+
+  it("falls back to plain code when Prism throws", () => {
+    const code = "let b = 2;";
+    const spy = vi.spyOn(Prism, "highlight").mockImplementationOnce(() => {
+      throw new Error("boom");
+    });
+    const result = highlightCode(code, "tsx");
+    expect(result).toBe(code);
+    spy.mockRestore();
+  });
+});

--- a/packages/code-explorer/vitest.config.ts
+++ b/packages/code-explorer/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+import path from "path";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "../../client/src"),
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- test code-explorer file tree building
- test highlight utility's error fallback
- configure vitest for code-explorer package

## Testing
- `npm test -- --root .`


------
https://chatgpt.com/codex/tasks/task_e_68ba179e38fc833184e372682745df4c