### PR TITLE
docs: add tech lead profile for Jordan Rowe

### DIFF
--- a/packages/code-explorer/Tech_Lead-Jordan_Rowe.md
+++ b/packages/code-explorer/Tech_Lead-Jordan_Rowe.md
@@ -1,0 +1,31 @@
+# Tech Lead — Jordan Rowe
+
+## 🧭 Introduction
+- **Name:** Jordan Rowe
+- **Role:** Tech Lead
+- **Pronouns:** they/them
+- **Mission:** Guide the team to craft insightful, resilient tools for mining data explorers.
+
+## 📚 Biography
+Jordan's background blends full-stack development with a passion for turning complex datasets into clear stories. They specialize in building collaborative tooling and nurturing engineering culture.
+
+## 🛠️ Core Skills & Tools
+- Languages: TypeScript, JavaScript, Python
+- Frameworks: React, Node.js, Express
+- Tools: Vitest, Vite, Docker, Git
+
+## 📞 Contact & Availability
+- Channels: Slack (`@jordan`), email (`jordan.rowe@example.com`)
+- Timezone: UTC−05:00
+
+## 🎯 Current Assignment
+Leading the integration of code exploration features into the platform.
+
+## 📝 Current Task Notes
+- Initial architecture drafted and under review.
+
+## 🗂️ Project Notes
+- Prioritize accessibility and performance across all new components.
+
+## 🚨 Urgent Notes
+


### PR DESCRIPTION
## Summary
- add tech lead profile for Jordan Rowe under code-explorer package

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba1edbf19483318fa7c40688019f88