### PR TITLE
docs: add frontend developer profile for Simon Hesher

### DIFF
--- a/packages/code-explorer/Frontend_Developer-Simon_Hesher.md
+++ b/packages/code-explorer/Frontend_Developer-Simon_Hesher.md
@@ -1,0 +1,32 @@
+# Frontend Developer — Simon Hesher
+
+## 🧭 Introduction
+- **Name:** Simon Hesher
+- **Role:** Frontend Developer
+- **Pronouns:** he/him
+- **Mission:** Craft intuitive, accessible interfaces that make complex data approachable.
+
+## 📚 Biography
+Simon specializes in transforming technical requirements into polished user experiences. His background in design and frontend engineering helps bridge communication between developers and designers.
+
+## 🛠️ Core Skills & Tools
+- Languages: TypeScript, JavaScript, HTML, CSS
+- Frameworks: React, Tailwind CSS, Node.js
+- Tools: Figma, Vitest, Git
+
+## 📞 Contact & Availability
+- Channels: Slack (`@simon`), email (`simon.hesher@example.com`)
+- Timezone: UTC−05:00
+
+## 🎯 Current Assignment
+Enhancing the code explorer's UI and UX for responsive, seamless navigation.
+
+## 📝 Current Task Notes
+- Refining navigation components for clarity and accessibility.
+- Collaborating with design on theme updates to improve readability.
+
+## 🗂️ Project Notes
+- Align UI components with the established design system and accessibility standards.
+
+## 🚨 Urgent Notes
+


### PR DESCRIPTION
## Summary
- add profile for Frontend Developer Simon Hesher with UI/UX-focused current assignments

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba220643608331a2112780b88bd347