### PR TITLE
Add QA engineer profile for Maria Li

### DIFF
--- a/packages/code-explorer/QA_Engineer-Maria_Li.md
+++ b/packages/code-explorer/QA_Engineer-Maria_Li.md
@@ -1,0 +1,32 @@
+# QA Engineer — Maria Li
+
+## 🧭 Introduction
+- **Name:** Maria Li
+- **Role:** QA Engineer
+- **Pronouns:** she/her
+- **Mission:** Safeguard product quality by uncovering defects before release.
+
+## 📚 Biography
+Maria brings a detail-oriented mindset shaped by years of testing complex web applications. She is passionate about preventing regressions through thoughtful automation and exploratory testing.
+
+## 🛠️ Core Skills & Tools
+- Languages: JavaScript, TypeScript, Python
+- Frameworks: Playwright, Vitest
+- Tools: Docker, Git, CI/CD pipelines
+
+## 📞 Contact & Availability
+- Channels: Slack (`@maria`), email (`maria.li@example.com`)
+- Timezone: UTC+08:00
+
+## 🎯 Current Assignment
+Expanding regression test suites for the code explorer package.
+
+## 📝 Current Task Notes
+- Reviewing recent bug reports to design targeted tests.
+
+## 🗂️ Project Notes
+- Intermittent failure when scanning large directories; reproduction requires nested symlinks.
+- Syntax highlighter occasionally misinterprets files without extensions.
+
+## 🚨 Urgent Notes
+


### PR DESCRIPTION
## Summary
- add QA engineer profile for Maria Li in code explorer package

## Testing
- `npm test`
- `npm run check` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ba223f2c008331880be067773a7b34