### PR TITLE
docs(code-explorer): add documentation ops profile

### DIFF
--- a/packages/code-explorer/Documentation_Ops-Alex_Kim.md
+++ b/packages/code-explorer/Documentation_Ops-Alex_Kim.md
@@ -1,0 +1,30 @@
+# Documentation & Ops — Alex Kim
+
+## 🧭 Introduction
+- **Name:** Alex Kim
+- **Role:** Documentation & Ops
+- **Pronouns:** they/them
+- **Mission:** Keep project knowledge clear and workflows running smoothly.
+
+## 📚 Biography
+Alex blends technical writing with operations experience, ensuring documentation and processes evolve with the codebase.
+
+## 🛠️ Core Skills & Tools
+- Languages: Markdown, JavaScript, Bash
+- Tools: Git, CI/CD pipelines, Notion
+
+## 📞 Contact & Availability
+- Channels: Slack (`@alex`), email (`alex.kim@example.com`)
+- Timezone: UTC+09:00
+
+## 🎯 Current Assignment
+Standardize repository documentation and automate release notes.
+
+## 📝 Current Task Notes
+- Drafting runbooks for code explorer deployment.
+
+## 🗂️ Project Notes
+- Reference documentation kept in `/docs`; update as features stabilize.
+
+## 🚨 Urgent Notes
+

--- a/packages/code-explorer/README.md
+++ b/packages/code-explorer/README.md
@@ -2,6 +2,8 @@
 
 This document summarizes current feedback on the blank‑screen issue and outlines acceptance criteria for loading, syntax highlighting, and error handling.
 
+Documentation & Ops is part of the core team, responsible for maintaining project documentation and operational workflows.
+
 ## Blank‑screen bug
 
 Team members reported that selecting a file in the explorer occasionally renders a blank panel. No loading indicator or error message is shown, leaving users unsure if the file is empty, still loading, or if an error occurred.
@@ -67,6 +69,12 @@ Further reading: [docs/syntax-highlighting.md](docs/syntax-highlighting.md) and 
 
 ## Team Profiles
 Each team member maintains a personal Markdown file to share status updates and contact information. These profiles help the team coordinate work and keep project context in one place, and every member is responsible for keeping their file current.
+
+### Profiles
+- [Tech Lead — Jordan Rowe](Tech_Lead-Jordan_Rowe.md): Oversees architecture and technical strategy.
+- [Frontend Developer — Simon Hesher](Frontend_Developer-Simon_Hesher.md): Builds user-facing features and UI components.
+- [QA Engineer — Maria Li](QA_Engineer-Maria_Li.md): Ensures product quality through testing.
+- [Documentation & Ops — Alex Kim](Documentation_Ops-Alex_Kim.md): Maintains project documentation and operational workflows.
 
 ### Section ownership and purpose
 


### PR DESCRIPTION
## Summary
- add Documentation & Ops profile and link from team list
- mention Documentation & Ops role in Code Explorer docs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba24d0ec988331bc3b3a523a127499