### PR TITLE
docs: expand code explorer architecture notes

### DIFF
--- a/packages/code-explorer/Frontend_Developer-Simon_Hesher.md
+++ b/packages/code-explorer/Frontend_Developer-Simon_Hesher.md
@@ -24,9 +24,32 @@ Enhancing the code explorer's UI and UX for responsive, seamless navigation.
 ## 📝 Current Task Notes
 - Refining navigation components for clarity and accessibility.
 - Collaborating with design on theme updates to improve readability.
+- Documenting prop and state requirements for upcoming explorer components.
+
+## 🔮 Future Designs
+- Cross-fade transitions when switching between the Function Browser, Canvas, and Code Pane.
+- Theme-aware animations for light/dark mode transitions.
 
 ## 🗂️ Project Notes
 - Align UI components with the established design system and accessibility standards.
+
+### Approved Architecture
+- **Function Library**
+  - **Target component:** Function Browser
+  - **Props/state:** `functions: FunctionMeta[]`, `filter: string`, `onSelect(id: string): void`
+  - **Styling or libraries:** Virtualized list styling with Tailwind; search handled via `cmdk`.
+- **Composition Canvas**
+  - **Target component:** Canvas
+  - **Props/state:** `nodes: Node[]`, `connections: Edge[]`, `onUpdate(state): void`
+  - **Styling or libraries:** Drag-and-drop via `@dnd-kit`; grid background using Tailwind.
+- **Unified Editing & Patch Engine**
+  - **Target component:** Code Pane
+  - **Props/state:** `files: FileMap`, `activeFile: string`, `onApplyPatch(patch): void`
+  - **Styling or libraries:** `prismjs` for syntax highlighting; `react-resizable-panels` for layout splits.
+- **Dependency & Conflict Handling**
+  - **Target components:** Code Pane, Canvas
+  - **Props/state:** `dependencyGraph: Graph`, `conflicts: Conflict[]`
+  - **Styling or libraries:** Alerts fetched with `@tanstack/react-query`; visual cues styled with Tailwind.
 
 ## 🚨 Urgent Notes
 


### PR DESCRIPTION
## Summary
- outline props/state and styling dependencies for Function Browser, Canvas, and Code Pane
- add Future Designs section with planned UI transitions
- focus Current Task Notes on active work, moving architecture details to Project Notes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba2912534c833184025ea4c5119030