### PR TITLE
feat: add function index and search

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -28,6 +28,7 @@ import BlogPostView from "@/pages/blog-post-view";
 import BuilderLab from "@/pages/BuilderLab";
 import { CardBuilderApp } from "../../packages/card-builder";
 import { CodeExplorerApp } from "../../packages/code-explorer";
+import FunctionSearchPage from "@/pages/function-search";
 
 function Router() {
   return (
@@ -79,6 +80,7 @@ function Router() {
       {/* Standalone tools routes */}
       <Route path="/card-builder" component={CardBuilderApp} />
       <Route path="/code-explorer" component={CodeExplorerApp} />
+      <Route path="/functions" component={FunctionSearchPage} />
 
       {/* Builder Lab route */}
       <Route path="/builder" component={BuilderLab} />

--- a/client/src/__tests__/functions-api.test.ts
+++ b/client/src/__tests__/functions-api.test.ts
@@ -1,0 +1,20 @@
+/* @vitest-environment node */
+import { describe, it, expect } from "vitest";
+import express from "express";
+import { functionIndex } from "../../../server/function-index";
+
+describe("/api/functions", () => {
+  it("returns the function index", async () => {
+    const app = express();
+    app.get("/api/functions", (_req, res) => {
+      res.json(functionIndex);
+    });
+    const server = app.listen(0);
+    const { port } = server.address() as any;
+    const res = await fetch(`http://127.0.0.1:${port}/api/functions`);
+    const data = await res.json();
+    expect(Array.isArray(data)).toBe(true);
+    expect(data.length).toBeGreaterThan(0);
+    server.close();
+  });
+});

--- a/client/src/__tests__/scan.test.ts
+++ b/client/src/__tests__/scan.test.ts
@@ -1,0 +1,35 @@
+/* @vitest-environment node */
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import fs from "fs";
+import path from "path";
+import os from "os";
+import { scan } from "../../../packages/code-explorer/scan.js";
+
+let tmpDir: string;
+
+beforeAll(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "scan-test-"));
+  const file = path.join(tmpDir, "a.ts");
+  fs.writeFileSync(
+    file,
+    `/**\n * Example\n * @tag util\n */\nfunction add(a: number, b: number): number {\n  return a + b;\n}\n`
+  );
+});
+
+afterAll(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("scan", () => {
+  it("produces function metadata", () => {
+    const index = scan(tmpDir);
+    expect(index).toEqual([
+      {
+        name: "add",
+        signature: "add(a: number, b: number): number",
+        path: "a.ts",
+        tags: ["util"],
+      },
+    ]);
+  });
+});

--- a/client/src/pages/function-search.tsx
+++ b/client/src/pages/function-search.tsx
@@ -1,0 +1,68 @@
+import { useEffect, useState } from "react";
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarHeader,
+  SidebarInput,
+  SidebarMenu,
+  SidebarMenuItem,
+  SidebarMenuButton,
+  SidebarProvider,
+} from "@/components/ui/sidebar";
+
+interface FunctionMeta {
+  name: string;
+  signature: string;
+  path: string;
+  tags: string[];
+}
+
+export function FunctionSearchPage() {
+  const [query, setQuery] = useState("");
+  const [functions, setFunctions] = useState<FunctionMeta[]>([]);
+
+  useEffect(() => {
+    fetch("/api/functions")
+      .then((res) => res.json())
+      .then((data) => setFunctions(data))
+      .catch(() => setFunctions([]));
+  }, []);
+
+  const filtered = functions.filter((f) =>
+    f.name.toLowerCase().includes(query.toLowerCase())
+  );
+
+  return (
+    <SidebarProvider>
+      <div className="flex h-screen">
+        <Sidebar>
+          <SidebarHeader>
+            <SidebarInput
+              placeholder="Search functions..."
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+            />
+          </SidebarHeader>
+          <SidebarContent>
+            <SidebarMenu>
+              {filtered.map((fn) => (
+                <SidebarMenuItem key={`${fn.path}-${fn.name}`}>
+                  <SidebarMenuButton asChild>
+                    <div className="flex flex-col items-start">
+                      <span>{fn.name}</span>
+                      <span className="text-xs text-muted-foreground">
+                        {fn.path}
+                      </span>
+                    </div>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+              ))}
+            </SidebarMenu>
+          </SidebarContent>
+        </Sidebar>
+      </div>
+    </SidebarProvider>
+  );
+}
+
+export default FunctionSearchPage;

--- a/server/function-index.ts
+++ b/server/function-index.ts
@@ -1,0 +1,7 @@
+import path from "path";
+import { scan } from "../packages/code-explorer/scan.js";
+
+const rootDir = path.resolve(import.meta.dirname, "..");
+export const functionIndex = scan(rootDir);
+
+export default functionIndex;

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -8,6 +8,7 @@ import { insertLeadSchema } from "@shared/schema";
 import { insertSiteLeadSchema } from "@shared/site-schema";
 import { createHubSpotContact, submitToHubSpotForm, testHubSpotConnection, type HubSpotContact } from "./hubspot";
 import { registerSiteRoutes } from "./site-routes";
+import { functionIndex } from "./function-index";
 
 export async function registerRoutes(app: Express): Promise<Server> {
   console.log('Registering routes...');
@@ -505,6 +506,10 @@ export async function registerRoutes(app: Express): Promise<Server> {
     } catch (error) {
       next(error);
     }
+  });
+
+  app.get("/api/functions", (_req, res) => {
+    res.json(functionIndex);
   });
 
   // Register multi-site routes


### PR DESCRIPTION
## Summary
- index project functions with signature, path, and tags
- expose generated function index through `/api/functions`
- add function search sidebar UI and supporting tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba328b74308331bdcd6178e303037f