### PR TITLE
feat: add function composition canvas

### DIFF
--- a/packages/code-explorer/src/App.tsx
+++ b/packages/code-explorer/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { Folder, Github, FilePlus } from "lucide-react";
 import { ActionCard } from "./components/ActionCard";
 import { Button } from "@/components/ui/button";
@@ -13,6 +13,11 @@ import {
 } from "@/components/ui/dialog";
 import { FileTree, TreeNode } from "./components/FileTree";
 import { FileViewer } from "./components/FileViewer";
+import {
+  CompositionCanvas,
+  CompositionNode,
+  Edge,
+} from "./components/CompositionCanvas";
 
 /**
 {
@@ -36,6 +41,22 @@ export function CodeExplorerApp() {
   const [filter, setFilter] = useState("");
   const [status, setStatus] = useState("");
   const [collapseKey, setCollapseKey] = useState(0);
+  const [composition, setComposition] = useState<{
+    nodes: CompositionNode[];
+    connections: Edge[];
+  }>(() => {
+    if (typeof window !== "undefined") {
+      const stored = localStorage.getItem("composition");
+      if (stored) return JSON.parse(stored);
+    }
+    return { nodes: [], connections: [] };
+  });
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      localStorage.setItem("composition", JSON.stringify(composition));
+    }
+  }, [composition]);
 
 
   /**
@@ -185,10 +206,20 @@ export function CodeExplorerApp() {
         </div>
         <div className="flex-1 p-4 overflow-auto">
           {selected ? (
-            <>
-              <div className="text-sm text-muted-foreground mb-2">{relative}</div>
-              <FileViewer path={selected} />
-            </>
+            <div className="flex h-full gap-4">
+              <div className="flex-1">
+                <div className="text-sm text-muted-foreground mb-2">{relative}</div>
+                <FileViewer path={selected} />
+              </div>
+              <div className="w-1/2 border-l pl-4">
+                <CompositionCanvas
+                  functions={relative ? [relative] : []}
+                  nodes={composition.nodes}
+                  connections={composition.connections}
+                  onUpdate={setComposition}
+                />
+              </div>
+            </div>
           ) : (
             <p className="text-sm text-muted-foreground">Select a file to view</p>
           )}

--- a/packages/code-explorer/src/components/CompositionCanvas.test.tsx
+++ b/packages/code-explorer/src/components/CompositionCanvas.test.tsx
@@ -1,0 +1,71 @@
+/* @vitest-environment jsdom */
+import React from "react";
+import { render, screen, fireEvent, within } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { CompositionCanvas, CompositionNode, Edge } from "./CompositionCanvas";
+
+function Wrapper({
+  functions = [],
+  initialNodes = [],
+  initialConnections = [],
+}: {
+  functions?: string[];
+  initialNodes?: CompositionNode[];
+  initialConnections?: Edge[];
+}) {
+  const [state, setState] = React.useState({
+    nodes: initialNodes,
+    connections: initialConnections,
+  });
+  return (
+    <CompositionCanvas
+      functions={functions}
+      nodes={state.nodes}
+      connections={state.connections}
+      onUpdate={setState}
+    />
+  );
+}
+
+describe("CompositionCanvas", () => {
+  it("places node on canvas when dropped", () => {
+    render(<Wrapper functions={["fn"]} />);
+    const palette = screen.getByTestId("palette-fn");
+    const canvas = screen.getByTestId("canvas");
+
+    fireEvent.dragStart(palette, {
+      dataTransfer: {
+        setData: () => {},
+      },
+    });
+    fireEvent.dragOver(canvas, { preventDefault: () => {} });
+    fireEvent.drop(canvas, {
+      dataTransfer: { getData: () => "fn" },
+      clientX: 10,
+      clientY: 10,
+    });
+
+    const canvasQueries = within(canvas);
+    expect(canvasQueries.getByText("fn")).toBeTruthy();
+  });
+
+  it("creates connection between nodes", () => {
+    const nodes: CompositionNode[] = [
+      { id: "a", name: "A", x: 0, y: 0 },
+      { id: "b", name: "B", x: 150, y: 0 },
+    ];
+    render(
+      <Wrapper
+        functions={[]}
+        initialNodes={nodes}
+        initialConnections={[]}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId("output-a"));
+    fireEvent.click(screen.getByTestId("input-b"));
+
+    expect(screen.getByTestId("edge-a-b")).toBeTruthy();
+  });
+});
+

--- a/packages/code-explorer/src/components/CompositionCanvas.tsx
+++ b/packages/code-explorer/src/components/CompositionCanvas.tsx
@@ -1,0 +1,139 @@
+import React, { useState, useEffect } from "react";
+import { nanoid } from "nanoid";
+
+export interface CompositionNode {
+  id: string;
+  name: string;
+  x: number;
+  y: number;
+}
+
+export interface Edge {
+  from: string;
+  to: string;
+}
+
+interface Props {
+  functions: string[];
+  nodes: CompositionNode[];
+  connections: Edge[];
+  onUpdate(state: { nodes: CompositionNode[]; connections: Edge[] }): void;
+}
+
+/**
+ * Basic composition canvas allowing drag-and-drop of function nodes and wiring.
+ */
+export function CompositionCanvas({ functions, nodes, connections, onUpdate }: Props) {
+  const [localNodes, setLocalNodes] = useState<CompositionNode[]>(nodes);
+  const [localConnections, setLocalConnections] = useState<Edge[]>(connections);
+  const [pending, setPending] = useState<string | null>(null);
+
+  useEffect(() => {
+    setLocalNodes(nodes);
+    setLocalConnections(connections);
+  }, [nodes, connections]);
+
+  function handleDragStart(e: React.DragEvent<HTMLDivElement>, fn: string) {
+    e.dataTransfer.setData("text/plain", fn);
+  }
+
+  function handleDrop(e: React.DragEvent<HTMLDivElement>) {
+    e.preventDefault();
+    const fn = e.dataTransfer.getData("text/plain");
+    if (!fn) return;
+    const rect = e.currentTarget.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+    const node: CompositionNode = { id: nanoid(), name: fn, x, y };
+    const updated = { nodes: [...localNodes, node], connections: localConnections };
+    setLocalNodes(updated.nodes);
+    onUpdate(updated);
+  }
+
+  function handleDragOver(e: React.DragEvent<HTMLDivElement>) {
+    e.preventDefault();
+  }
+
+  function startConnection(id: string) {
+    setPending(id);
+  }
+
+  function finishConnection(id: string) {
+    if (pending && pending !== id) {
+      const edge = { from: pending, to: id };
+      const updated = { nodes: localNodes, connections: [...localConnections, edge] };
+      setLocalConnections(updated.connections);
+      onUpdate(updated);
+    }
+    setPending(null);
+  }
+
+  return (
+    <div className="flex h-full">
+      <div className="w-32 border-r p-2">
+        {functions.map((fn) => (
+          <div
+            key={fn}
+            draggable
+            data-testid={`palette-${fn}`}
+            onDragStart={(e) => handleDragStart(e, fn)}
+            className="p-2 mb-2 border rounded bg-background cursor-move text-xs"
+          >
+            {fn}
+          </div>
+        ))}
+      </div>
+      <div
+        className="flex-1 relative bg-white"
+        data-testid="canvas"
+        onDrop={handleDrop}
+        onDragOver={handleDragOver}
+      >
+        <svg className="absolute inset-0 pointer-events-none">
+          {localConnections.map((c) => {
+            const from = localNodes.find((n) => n.id === c.from);
+            const to = localNodes.find((n) => n.id === c.to);
+            if (!from || !to) return null;
+            const x1 = from.x + 120;
+            const y1 = from.y + 25;
+            const x2 = to.x;
+            const y2 = to.y + 25;
+            return (
+              <line
+                key={`${c.from}-${c.to}`}
+                data-testid={`edge-${c.from}-${c.to}`}
+                x1={x1}
+                y1={y1}
+                x2={x2}
+                y2={y2}
+                stroke="black"
+              />
+            );
+          })}
+        </svg>
+        {localNodes.map((n) => (
+          <div
+            key={n.id}
+            className="absolute border rounded p-2 bg-background text-xs"
+            style={{ left: n.x, top: n.y, width: 120 }}
+          >
+            <div>{n.name}</div>
+            <div className="flex justify-between mt-2">
+              <div
+                className="w-3 h-3 bg-blue-500 rounded-full cursor-pointer"
+                data-testid={`input-${n.id}`}
+                onClick={() => finishConnection(n.id)}
+              />
+              <div
+                className="w-3 h-3 bg-green-500 rounded-full cursor-pointer"
+                data-testid={`output-${n.id}`}
+                onClick={() => startConnection(n.id)}
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add CompositionCanvas component for dragging function nodes and wiring connections
- integrate canvas into CodeExplorerApp with local storage persistence
- test node placement and basic wiring

## Testing
- `npm test`
- `npx vitest run packages/code-explorer/src/components/CompositionCanvas.test.tsx -c packages/code-explorer/vitest.config.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ba341712588331be46220253776814