### PR TITLE
refactor: convert legacy comments to json metadata

### DIFF
--- a/packages/card-builder/src/components/ActionCard.tsx
+++ b/packages/card-builder/src/components/ActionCard.tsx
@@ -10,6 +10,16 @@ interface ActionCardProps {
   onClick: () => void;
 }
 
+/**
+{
+  "friendlyName": "action card",
+  "description": "Reusable card component with icon, description and call-to-action.",
+  "editCount": 1,
+  "tags": ["ui", "card"],
+  "location": "packages/card-builder/src/components/ActionCard.tsx > ActionCard",
+  "notes": "Triggers provided onClick handler when button is pressed."
+}
+*/
 export function ActionCard({ icon: Icon, title, description, cta, onClick }: ActionCardProps) {
   return (
     <Card className="w-full max-w-sm transition-shadow hover:shadow-md">

--- a/packages/code-explorer/file-tree.js
+++ b/packages/code-explorer/file-tree.js
@@ -2,12 +2,15 @@ import fs from 'fs';
 import path from 'path';
 
 /**
- * Type: Recursive utility function
- * Location: packages/code-explorer/file-tree.js > buildFileTree
- * Description: Builds an object representing the directory structure of a path.
- * Notes: Skips .git and node_modules folders during traversal.
- * EditCounter: 1
- */
+{
+  "friendlyName": "build file tree",
+  "description": "Builds an object representing the directory structure of a path.",
+  "editCount": 2,
+  "tags": [],
+  "location": "packages/code-explorer/file-tree.js > buildFileTree",
+  "notes": "Skips .git and node_modules folders during traversal."
+}
+*/
 export function buildFileTree(dir) {
   const name = path.basename(dir);
   const item = { name, path: dir };

--- a/packages/code-explorer/scan.js
+++ b/packages/code-explorer/scan.js
@@ -3,12 +3,15 @@ import path from 'path';
 import ts from 'typescript';
 
 /**
- * Type: Recursive utility function
- * Location: packages/code-explorer/scan.js > collectFiles
- * Description: Traverses directories to gather source files with JS/TS extensions.
- * Notes: Skips node_modules and hidden folders.
- * EditCounter: 1
- */
+{
+  "friendlyName": "collect files",
+  "description": "Traverses directories to gather source files with JS/TS extensions.",
+  "editCount": 2,
+  "tags": [],
+  "location": "packages/code-explorer/scan.js > collectFiles",
+  "notes": "Skips node_modules and hidden folders."
+}
+*/
 function collectFiles(dir, files = []) {
   for (const entry of fs.readdirSync(dir)) {
     const full = path.join(dir, entry);
@@ -24,12 +27,15 @@ function collectFiles(dir, files = []) {
 }
 
 /**
- * Type: Parser function
- * Location: packages/code-explorer/scan.js > parseFile
- * Description: Parses a source file to extract declared function signatures.
- * Notes: Utilizes the TypeScript compiler API for analysis.
- * EditCounter: 1
- */
+{
+  "friendlyName": "parse file",
+  "description": "Parses a source file to extract declared function signatures.",
+  "editCount": 2,
+  "tags": [],
+  "location": "packages/code-explorer/scan.js > parseFile",
+  "notes": "Utilizes the TypeScript compiler API for analysis."
+}
+*/
 function parseFile(file, rootDir) {
   const sourceText = fs.readFileSync(file, 'utf8');
   const sourceFile = ts.createSourceFile(file, sourceText, ts.ScriptTarget.Latest, true);
@@ -58,17 +64,30 @@ function parseFile(file, rootDir) {
 }
 
 /**
- * Type: Utility function
- * Location: packages/code-explorer/scan.js > scan
- * Description: Produces parsed function data for all source files in a directory.
- * Notes: Combines collectFiles and parseFile helpers.
- * EditCounter: 1
- */
+{
+  "friendlyName": "scan directory",
+  "description": "Produces parsed function data for all source files in a directory.",
+  "editCount": 2,
+  "tags": [],
+  "location": "packages/code-explorer/scan.js > scan",
+  "notes": "Combines collectFiles and parseFile helpers."
+}
+*/
 export function scan(dir) {
   const files = collectFiles(dir);
   return files.flatMap((f) => parseFile(f, dir));
 }
 
+/**
+{
+  "friendlyName": "scan to json",
+  "description": "Serializes scan results to formatted JSON.",
+  "editCount": 1,
+  "tags": [],
+  "location": "packages/code-explorer/scan.js > scanToJSON",
+  "notes": "Wraps scan with JSON.stringify."
+}
+*/
 export function scanToJSON(dir) {
   return JSON.stringify(scan(dir), null, 2);
 }

--- a/packages/code-explorer/src/components/ActionCard.tsx
+++ b/packages/code-explorer/src/components/ActionCard.tsx
@@ -11,12 +11,15 @@ interface ActionCardProps {
 }
 
 /**
- * Type: React component
- * Location: packages/code-explorer/src/components/ActionCard.tsx > ActionCard
- * Description: Displays a clickable card used on the explorer landing page.
- * Notes: Renders provided icon, title and call-to-action button.
- * EditCounter: 1
- */
+{
+  "friendlyName": "action card",
+  "description": "Displays a clickable card used on the explorer landing page.",
+  "editCount": 2,
+  "tags": ["ui", "card"],
+  "location": "packages/code-explorer/src/components/ActionCard.tsx > ActionCard",
+  "notes": "Renders provided icon, title and call-to-action button."
+}
+*/
 export function ActionCard({ icon: Icon, title, description, cta, onClick }: ActionCardProps) {
   return (
     <Card className="w-full max-w-sm transition-shadow hover:shadow-md">

--- a/packages/code-explorer/src/components/FileTree.tsx
+++ b/packages/code-explorer/src/components/FileTree.tsx
@@ -18,12 +18,15 @@ interface FileTreeProps {
 }
 
 /**
- * Type: Helper function
- * Location: packages/code-explorer/src/components/FileTree.tsx > matchesFilter
- * Description: Checks if a tree node or its descendants match the search filter.
- * Notes: Recursively examines child nodes.
- * EditCounter: 1
- */
+{
+  "friendlyName": "matches filter",
+  "description": "Checks if a tree node or its descendants match the search filter.",
+  "editCount": 2,
+  "tags": [],
+  "location": "packages/code-explorer/src/components/FileTree.tsx > matchesFilter",
+  "notes": "Recursively examines child nodes."
+}
+*/
 function matchesFilter(node: TreeNode, filter: string): boolean {
   if (!filter) return true;
   const lower = filter.toLowerCase();
@@ -32,12 +35,15 @@ function matchesFilter(node: TreeNode, filter: string): boolean {
 }
 
 /**
- * Type: Helper function
- * Location: packages/code-explorer/src/components/FileTree.tsx > fileColor
- * Description: Returns a Tailwind text color class based on file extension.
- * Notes: Used for syntax-aware coloring in the tree.
- * EditCounter: 1
- */
+{
+  "friendlyName": "file color",
+  "description": "Returns a Tailwind text color class based on file extension.",
+  "editCount": 2,
+  "tags": [],
+  "location": "packages/code-explorer/src/components/FileTree.tsx > fileColor",
+  "notes": "Used for syntax-aware coloring in the tree."
+}
+*/
 function fileColor(name: string): string {
   if (/\.(ts|tsx|js|jsx)$/.test(name)) return "text-blue-500";
   if (/\.json$/.test(name)) return "text-green-500";

--- a/packages/code-explorer/src/components/FileViewer.tsx
+++ b/packages/code-explorer/src/components/FileViewer.tsx
@@ -27,12 +27,15 @@ export function FileViewer({ path }: Props) {
 
   useEffect(() => {
     /**
-     * Type: Async helper function
-     * Location: packages/code-explorer/src/components/FileViewer.tsx > useEffect load
-     * Description: Retrieves file contents from the backend for the specified path.
-     * Notes: Updates local state once the content is loaded.
-     * EditCounter: 1
-     */
+    {
+      "friendlyName": "load file",
+      "description": "Retrieves file contents from the backend for the specified path.",
+      "editCount": 2,
+      "tags": [],
+      "location": "packages/code-explorer/src/components/FileViewer.tsx > useEffect load",
+      "notes": "Updates local state once the content is loaded."
+    }
+    */
     async function load() {
       const res = await fetch(`/code-explorer/api/file?path=${encodeURIComponent(path)}`);
       const text = await res.text();

--- a/server/explorer.ts
+++ b/server/explorer.ts
@@ -19,12 +19,15 @@ app.use(express.json());
 let currentRepoDir: string | null = null;
 
 /**
- * Type: Express route handler
- * Location: server/explorer.ts > POST /code-explorer/api/clone
- * Description: Clones a GitHub repository to a temp directory and returns its file tree.
- * Notes: Updates currentRepoDir for subsequent file fetches.
- * EditCounter: 1
- */
+{
+  "friendlyName": "clone route",
+  "description": "Clones a GitHub repository to a temp directory and returns its file tree.",
+  "editCount": 2,
+  "tags": ["express", "route"],
+  "location": "server/explorer.ts > POST /code-explorer/api/clone",
+  "notes": "Updates currentRepoDir for subsequent file fetches."
+}
+*/
 app.post("/code-explorer/api/clone", async (req, res) => {
   try {
     const repo: string = req.body.repo;
@@ -43,12 +46,15 @@ app.post("/code-explorer/api/clone", async (req, res) => {
 });
 
 /**
- * Type: Express route handler
- * Location: server/explorer.ts > GET /code-explorer/api/file
- * Description: Reads and returns the contents of a file within the cloned repository.
- * Notes: Validates that requested path resides in the current repository.
- * EditCounter: 1
- */
+{
+  "friendlyName": "get file route",
+  "description": "Reads and returns the contents of a file within the cloned repository.",
+  "editCount": 2,
+  "tags": ["express", "route"],
+  "location": "server/explorer.ts > GET /code-explorer/api/file",
+  "notes": "Validates that requested path resides in the current repository."
+}
+*/
 app.get("/code-explorer/api/file", async (req, res) => {
   const filePath = req.query.path as string | undefined;
   try {
@@ -63,11 +69,15 @@ app.get("/code-explorer/api/file", async (req, res) => {
 });
 
 /**
- * Type: Express route handler
- * Location: server/explorer.ts > POST /code-explorer/api/save
- * Description: Applies a unified diff patch to the specified file.
- * Notes: Validates path against current repository root.
- */
+{
+  "friendlyName": "save file route",
+  "description": "Applies a unified diff patch to the specified file.",
+  "editCount": 1,
+  "tags": ["express", "route"],
+  "location": "server/explorer.ts > POST /code-explorer/api/save",
+  "notes": "Validates path against current repository root."
+}
+*/
 app.post("/code-explorer/api/save", async (req, res) => {
   const { path: filePath, patch } = req.body || {};
   try {
@@ -88,12 +98,15 @@ app.post("/code-explorer/api/save", async (req, res) => {
 const server = createServer(app);
 
 /**
- * Type: Async IIFE
- * Location: server/explorer.ts > server startup
- * Description: Configures Vite middleware and starts the explorer development server.
- * Notes: Automatically opens the explorer URL in the default browser.
- * EditCounter: 1
- */
+{
+  "friendlyName": "explorer startup",
+  "description": "Configures Vite middleware and starts the explorer development server.",
+  "editCount": 2,
+  "tags": ["startup"],
+  "location": "server/explorer.ts > server startup",
+  "notes": "Automatically opens the explorer URL in the default browser."
+}
+*/
 (async () => {
   const rootDir = path.resolve(import.meta.dirname, "..", "packages", "code-explorer");
   await setupViteFor(app, server, rootDir, "/code-explorer");


### PR DESCRIPTION
## Summary
- replace legacy block comments with JSON metadata schema
- add missing annotations for exported utilities and components
- update editCount values for modified helpers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba35c184e883319413110d10618eb8