### PR TITLE
test: add coverage for code explorer components

### DIFF
--- a/packages/code-explorer/src/App.test.tsx
+++ b/packages/code-explorer/src/App.test.tsx
@@ -1,0 +1,66 @@
+/* @vitest-environment jsdom */
+import React from "react";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { CodeExplorerApp } from "./App";
+vi.mock("./components/FileViewer", () => ({ FileViewer: () => <div>viewer</div> }));
+vi.mock("./components/CompositionCanvas", () => ({ CompositionCanvas: () => <div /> }));
+
+vi.mock("prismjs", () => ({
+  default: { highlightAll: vi.fn(), highlight: (code: string) => code, languages: { tsx: {} } },
+  highlightAll: vi.fn(),
+  highlight: (code: string) => code,
+  languages: { tsx: {} },
+}));
+vi.mock("prismjs/components/prism-typescript", () => ({}));
+vi.mock("prismjs/components/prism-javascript", () => ({}));
+vi.mock("prismjs/components/prism-jsx", () => ({}));
+vi.mock("prismjs/components/prism-tsx", () => ({}));
+vi.mock("@/components/ui/button", () => ({ Button: (props: any) => <button {...props} /> }));
+vi.mock("@/components/ui/input", () => ({ Input: (props: any) => <input {...props} /> }));
+vi.mock("@/components/ui/dialog", () => ({
+  Dialog: ({ children, open }: any) => (open ? <div>{children}</div> : null),
+  DialogContent: ({ children }: any) => <div>{children}</div>,
+  DialogHeader: ({ children }: any) => <div>{children}</div>,
+  DialogTitle: ({ children }: any) => <div>{children}</div>,
+  DialogDescription: ({ children }: any) => <div>{children}</div>,
+  DialogFooter: ({ children }: any) => <div>{children}</div>,
+}));
+vi.mock("@/components/ui/card", () => ({
+  Card: ({ children }: any) => <div>{children}</div>,
+  CardHeader: ({ children }: any) => <div>{children}</div>,
+  CardTitle: ({ children }: any) => <div>{children}</div>,
+  CardDescription: ({ children }: any) => <div>{children}</div>,
+  CardContent: ({ children }: any) => <div>{children}</div>,
+}));
+
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  global.fetch = vi.fn();
+});
+
+afterEach(() => {
+  cleanup();
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+describe("CodeExplorerApp", () => {
+  it("renders cards and shows error on invalid URL", async () => {
+    render(<CodeExplorerApp />);
+    // rendering home screen
+    expect(screen.getByText("Import GitHub repository")).toBeTruthy();
+
+    // interaction: open import dialog
+    fireEvent.click(screen.getAllByText("Import")[0]);
+    fireEvent.change(screen.getByPlaceholderText("https://github.com/user/repo"), {
+      target: { value: "invalid" },
+    });
+    fireEvent.click(screen.getAllByText("Import")[1]);
+
+    // error path: invalid URL message
+    expect(await screen.findByText("Please enter a valid GitHub URL")).toBeTruthy();
+  });
+});
+

--- a/packages/code-explorer/src/components/ActionCard.test.tsx
+++ b/packages/code-explorer/src/components/ActionCard.test.tsx
@@ -1,0 +1,69 @@
+/* @vitest-environment jsdom */
+import React from "react";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { ActionCard } from "./ActionCard";
+
+vi.mock("@/components/ui/card", () => ({
+  Card: ({ children }: any) => <div>{children}</div>,
+  CardHeader: ({ children }: any) => <div>{children}</div>,
+  CardTitle: ({ children }: any) => <div>{children}</div>,
+  CardDescription: ({ children }: any) => <div>{children}</div>,
+  CardContent: ({ children }: any) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: (props: any) => <button {...props} />,
+}));
+
+afterEach(() => cleanup());
+
+describe("ActionCard", () => {
+  it("renders icon, title, description and cta", () => {
+    const Icon = () => <svg data-testid="icon" />;
+    render(
+      <ActionCard
+        icon={Icon}
+        title="Title"
+        description="Description"
+        cta="Go"
+        onClick={() => {}}
+      />
+    );
+    expect(screen.getByTestId("icon")).toBeTruthy();
+    expect(screen.getByText("Title")).toBeTruthy();
+    expect(screen.getByText("Description")).toBeTruthy();
+    expect(screen.getByText("Go")).toBeTruthy();
+  });
+
+  it("fires onClick when button is clicked", () => {
+    const Icon = () => <svg />;
+    const onClick = vi.fn();
+    render(
+      <ActionCard
+        icon={Icon}
+        title="Title"
+        description="Description"
+        cta="Go"
+        onClick={onClick}
+      />
+    );
+    fireEvent.click(screen.getByText("Go"));
+    expect(onClick).toHaveBeenCalled();
+  });
+
+  it("handles missing onClick without crashing", () => {
+    const Icon = () => <svg />;
+    render(
+      <ActionCard
+        icon={Icon}
+        title="Title"
+        description="Description"
+        cta="Go"
+        onClick={undefined as any}
+      />
+    );
+    expect(() => fireEvent.click(screen.getByText("Go"))).not.toThrow();
+  });
+});
+

--- a/packages/code-explorer/src/components/FileTree.test.tsx
+++ b/packages/code-explorer/src/components/FileTree.test.tsx
@@ -1,0 +1,68 @@
+/* @vitest-environment jsdom */
+import React from "react";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { FileTree, TreeNode } from "./FileTree";
+
+vi.mock("lucide-react", () => ({
+  ChevronRight: (props: any) => <span data-testid="chevron-right" {...props} />,
+  ChevronDown: (props: any) => <span data-testid="chevron-down" {...props} />,
+  Folder: (props: any) => <span data-testid="folder" {...props} />,
+  FileText: (props: any) => <span data-testid="file-text" {...props} />,
+}));
+
+const tree: TreeNode = {
+  name: "root",
+  path: "/root",
+  children: [
+    {
+      name: "src",
+      path: "/root/src",
+      children: [{ name: "index.ts", path: "/root/src/index.ts" }],
+    },
+    { name: "README.md", path: "/root/README.md" },
+  ],
+};
+
+afterEach(() => cleanup());
+
+describe("FileTree", () => {
+  it("renders directories and files", () => {
+    render(<FileTree node={tree} selected={null} onSelect={() => {}} filter="" isRoot />);
+    expect(screen.getByText("root")).toBeTruthy();
+    expect(screen.getByText("src")).toBeTruthy();
+    expect(screen.getByText("README.md")).toBeTruthy();
+  });
+
+  it("toggles folder and selects file", () => {
+    const onSelect = vi.fn();
+    render(<FileTree node={tree} selected={null} onSelect={onSelect} filter="" isRoot />);
+    const folder = screen.getByText("src");
+    expect(screen.queryByText("index.ts")).toBeNull();
+    fireEvent.click(folder);
+    const file = screen.getByText("index.ts");
+    fireEvent.click(file);
+    expect(onSelect).toHaveBeenCalledWith("/root/src/index.ts");
+  });
+
+  it("returns null when filter excludes node", () => {
+    const { container } = render(
+      <FileTree node={tree} selected={null} onSelect={() => {}} filter="xyz" isRoot />
+    );
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("collapses when collapseKey changes", () => {
+    const { rerender } = render(
+      <FileTree node={tree} selected={null} onSelect={() => {}} filter="" isRoot collapseKey={0} />
+    );
+    const folder = screen.getByText("src");
+    fireEvent.click(folder); // open
+    expect(screen.getByText("index.ts")).toBeTruthy();
+    rerender(
+      <FileTree node={tree} selected={null} onSelect={() => {}} filter="" isRoot collapseKey={1} />
+    );
+    expect(screen.queryByText("index.ts")).toBeNull();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add ActionCard tests for rendering, click handling, and safety with missing handler
- cover FileTree directory toggling, selection, filtering, and collapse-all logic
- verify CodeExplorerApp shows an error on invalid GitHub URLs

## Testing
- `npm test`
- `npx vitest run packages/code-explorer/src/components/ActionCard.test.tsx packages/code-explorer/src/components/FileTree.test.tsx packages/code-explorer/src/App.test.tsx --config packages/code-explorer/vitest.config.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ba371547e08331a4aad3c8fc445371