### PR TITLE
feat(explorer): improve highlight and docs

### DIFF
--- a/packages/code-explorer/Documentation_Ops-Alex_Kim.md
+++ b/packages/code-explorer/Documentation_Ops-Alex_Kim.md
@@ -1,0 +1,28 @@
+# Documentation & Ops – Alex Kim
+
+## Introduction
+Alex Kim (they/them) – keeping Code Explorer docs and workflows humming.
+
+## Biography
+Technical writer and operations specialist focused on developer productivity.
+
+## Core Skills & Tools
+Markdown, Git, process automation.
+
+## Contact & Availability
+alex@example.com – UTC‑5, flexible schedule.
+
+## Current Assignment
+Establish profile documentation standards and README guidance.
+
+## Current Task Notes
+- Drafted process resources and team profile template.
+
+## Project Notes
+- N/A
+
+## Future Designs
+- Automate profile linting.
+
+## Urgent Notes
+*(none)*

--- a/packages/code-explorer/Frontend_Developer-Simon_Hesher.md
+++ b/packages/code-explorer/Frontend_Developer-Simon_Hesher.md
@@ -1,0 +1,29 @@
+# Frontend Developer – Simon Hesher
+
+## Introduction
+Simon Hesher (he/him) – crafting engaging UI for Code Explorer.
+
+## Biography
+Frontend engineer with a passion for developer experience and visual tools.
+
+## Core Skills & Tools
+React, TypeScript, Tailwind, Vite.
+
+## Contact & Availability
+simon@example.com – UTC‑5, 11am‑7pm.
+
+## Current Assignment
+Ensure files load and highlight correctly when selected in the tree.
+
+## Current Task Notes
+- Implemented extension-aware `highlightCode` utility.
+- Updated `FileViewer` to use the new helper.
+
+## Project Notes
+- Initial file tree and viewer scaffolding complete.
+
+## Future Designs
+- Integrate editable code pane for round-trip edits.
+
+## Urgent Notes
+*(none)*

--- a/packages/code-explorer/Product_Manager-Ava_Wu.md
+++ b/packages/code-explorer/Product_Manager-Ava_Wu.md
@@ -1,0 +1,29 @@
+# Product Manager – Ava Wu
+
+## Introduction
+Ava Wu (she/her) – Product Manager ensuring Code Explorer solves real developer pain.
+
+## Biography
+Seasoned PM with a focus on developer tools and collaborative workflows.
+
+## Core Skills & Tools
+Product strategy, user research, Jira, Notion.
+
+## Contact & Availability
+ava@example.com – UTC‑5, 9am‑5pm.
+
+## Current Assignment
+Define requirements for resilient file viewing and editing.
+
+## Current Task Notes
+- Gathered feedback about blank viewer issue.
+- Coordinating with engineering for fix.
+
+## Project Notes
+- Initial import flow defined.
+
+## Future Designs
+- Outline roadmap for composition canvas.
+
+## Urgent Notes
+*(none)*

--- a/packages/code-explorer/QA_Engineer-Maria_Li.md
+++ b/packages/code-explorer/QA_Engineer-Maria_Li.md
@@ -1,0 +1,29 @@
+# QA Engineer – Maria Li
+
+## Introduction
+Maria Li (she/her) – safeguarding quality for Code Explorer.
+
+## Biography
+Quality engineer experienced in automated testing and exploratory workflows.
+
+## Core Skills & Tools
+Vitest, Testing Library, Cypress.
+
+## Contact & Availability
+maria@example.com – UTC‑5, 9am‑5pm.
+
+## Current Assignment
+Expand coverage for file viewing and highlighting.
+
+## Current Task Notes
+- Added tests for `highlightCode` fallback behavior.
+- Verified file viewer renders content even when Prism fails.
+
+## Project Notes
+- Baseline import flow tests exist.
+
+## Future Designs
+- Plan regression suite for composition canvas.
+
+## Urgent Notes
+*(none)*

--- a/packages/code-explorer/README.md
+++ b/packages/code-explorer/README.md
@@ -1,0 +1,42 @@
+# Code Explorer
+
+A standalone module for browsing and editing code repositories in the Mining Syndicate Platform. It can import a GitHub repo, display a file tree and render files with syntax highlighting.
+
+## Development
+
+- `npm run dev:explorer` – start the explorer at `http://localhost:5000/code-explorer`.
+- `npm test` – run unit tests for the explorer package.
+
+## Syntax Highlighting & Testing
+
+The viewer uses a small Prism wrapper to highlight TypeScript and JavaScript. To add support for another language:
+
+1. Install or import the appropriate Prism grammar.
+2. Update `src/utils/highlight.ts` to map the file extension to that grammar.
+3. Run `npm test` to ensure highlighting works and existing tests pass.
+
+## Team Profiles
+
+Each team member maintains a personal Markdown file in this folder to aid handoffs.
+
+Required sections for every profile:
+
+1. **Introduction** – name, role, one‑line mission.
+2. **Biography** – background and expertise.
+3. **Core Skills & Tools** – key technologies used.
+4. **Contact & Availability** – preferred channels and hours.
+5. **Current Assignment** – present work focus.
+6. **Current Task Notes** – latest status on the assignment.
+7. **Project Notes** – archive of important decisions or references (past).
+8. **Future Designs** – ideas not yet in scope.
+9. **Urgent Notes** – empty when no blockers exist.
+
+### Members
+
+- [Product Manager – Ava Wu](./Product_Manager-Ava_Wu.md)
+- [Tech Lead – Jordan Rowe](./Tech_Lead-Jordan_Rowe.md)
+- [Frontend Developer – Simon Hesher](./Frontend_Developer-Simon_Hesher.md)
+- [QA Engineer – Maria Li](./QA_Engineer-Maria_Li.md)
+- [Documentation & Ops – Alex Kim](./Documentation_Ops-Alex_Kim.md)
+
+See `docs/Documentation_Process_Resources.md` for detailed guidelines.

--- a/packages/code-explorer/Tech_Lead-Jordan_Rowe.md
+++ b/packages/code-explorer/Tech_Lead-Jordan_Rowe.md
@@ -1,0 +1,29 @@
+# Tech Lead – Jordan Rowe
+
+## Introduction
+Jordan Rowe (he/him) – guiding technical direction for Code Explorer.
+
+## Biography
+Full-stack engineer specializing in AST tooling and scalable architectures.
+
+## Core Skills & Tools
+TypeScript, Node.js, React, AST parsers.
+
+## Contact & Availability
+jordan@example.com – UTC‑5, 10am‑6pm.
+
+## Current Assignment
+Review syntax highlighting strategy and file loading reliability.
+
+## Current Task Notes
+- Proposed extension-based highlight utility.
+- Assessing multi-file edit feasibility.
+
+## Project Notes
+- Decided to use TypeScript compiler API for scanning functions.
+
+## Future Designs
+- Virtual AST for recomposable snippets.
+
+## Urgent Notes
+*(none)*

--- a/packages/code-explorer/docs/Documentation_Process_Resources.md
+++ b/packages/code-explorer/docs/Documentation_Process_Resources.md
@@ -1,0 +1,24 @@
+# Documentation Process & Resources
+
+Each team member maintains a Markdown profile in `packages/code-explorer`. Use these guidelines when updating files:
+
+## Sections
+
+1. **Introduction** – Name, role, pronouns, mission statement.
+2. **Biography** – Short background and relevant experience.
+3. **Core Skills & Tools** – Technologies or tools frequently used.
+4. **Contact & Availability** – Communication channels and timezone.
+5. **Current Assignment** – Active work item.
+6. **Current Task Notes** – Day‑to‑day updates on the assignment.
+7. **Project Notes** – Archive of completed decisions or historical context (past).
+8. **Future Designs** – Ideas or plans not yet in development (future).
+9. **Urgent Notes** – Items needing immediate attention; remove when resolved.
+
+## Update Workflow
+
+- Before starting work, read relevant teammate profiles for context.
+- After finishing a task, move important outcomes into **Project Notes**.
+- Keep **Urgent Notes** empty unless a blocker arises.
+- Follow the naming convention `<Role>_<Name>-<Surname>.md`.
+
+These docs ensure smooth handoffs across Product, Engineering, QA, and Ops.

--- a/packages/code-explorer/src/components/FileViewer.test.tsx
+++ b/packages/code-explorer/src/components/FileViewer.test.tsx
@@ -1,0 +1,33 @@
+/* @vitest-environment jsdom */
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { FileViewer } from "./FileViewer";
+import Prism from "prismjs";
+
+vi.mock("@/components/ui/button", () => ({
+  Button: (props: any) => <button {...props} />,
+}));
+
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+});
+
+describe("FileViewer", () => {
+  it("renders code even when Prism lacks grammar", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, text: async () => "let x = 1;" });
+    global.fetch = fetchMock as any;
+    vi.spyOn(Prism, "highlight").mockImplementationOnce(() => {
+      throw new Error("missing grammar");
+    });
+
+    render(<FileViewer path="/repo/test.ts" />);
+    await screen.findByText((_, el) => el?.textContent === "let x = 1;");
+  });
+});

--- a/packages/code-explorer/src/components/FileViewer.tsx
+++ b/packages/code-explorer/src/components/FileViewer.tsx
@@ -1,8 +1,6 @@
 import React, { useEffect, useState } from "react";
-import Prism from "prismjs";
-import "prismjs/components/prism-typescript";
-import "prismjs/components/prism-javascript";
 import { Button } from "@/components/ui/button";
+import { highlightCode } from "../utils/highlight";
 
 interface Props {
   path: string;
@@ -13,7 +11,7 @@ interface Props {
  * Location: packages/code-explorer/src/components/FileViewer.tsx > FileViewer
  * Description: Fetches and displays highlighted source code with line numbers.
  * Notes: Provides copy and fullscreen controls for the current file.
- * EditCounter: 1
+ * EditCounter: 3
  */
 export function FileViewer({ path }: Props) {
   const [code, setCode] = useState("");
@@ -34,10 +32,6 @@ export function FileViewer({ path }: Props) {
     }
     if (path) load();
   }, [path]);
-
-  useEffect(() => {
-    Prism.highlightAll();
-  }, [code]);
 
   const lines = code.split("\n");
 
@@ -62,7 +56,10 @@ export function FileViewer({ path }: Props) {
               <div key={i}>{i + 1}</div>
             ))}
           </code>
-          <code className="pl-4" dangerouslySetInnerHTML={{ __html: Prism.highlight(code, Prism.languages.tsx, "tsx") }} />
+          <code
+            className="pl-4"
+            dangerouslySetInnerHTML={{ __html: highlightCode(code, path.split(".").pop() || "") }}
+          />
         </pre>
       </div>
     </div>

--- a/packages/code-explorer/src/import-flow.test.tsx
+++ b/packages/code-explorer/src/import-flow.test.tsx
@@ -12,6 +12,8 @@ vi.mock("prismjs", () => ({
 }));
 vi.mock("prismjs/components/prism-typescript", () => ({}));
 vi.mock("prismjs/components/prism-javascript", () => ({}));
+vi.mock("prismjs/components/prism-jsx", () => ({}));
+vi.mock("prismjs/components/prism-tsx", () => ({}));
 vi.mock("@/components/ui/button", () => ({
   Button: (props: any) => <button {...props} />,
 }));

--- a/packages/code-explorer/src/utils/highlight.test.ts
+++ b/packages/code-explorer/src/utils/highlight.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi } from "vitest";
+import Prism from "prismjs";
+import { highlightCode } from "./highlight";
+
+describe("highlightCode", () => {
+  it("highlights TypeScript code", () => {
+    const code = "const x: number = 1;";
+    const result = highlightCode(code, "ts");
+    expect(result).not.toBe(code);
+  });
+
+  it("returns original code when Prism throws", () => {
+    const code = "let x = 1;";
+    vi.spyOn(Prism, "highlight").mockImplementationOnce(() => {
+      throw new Error("missing grammar");
+    });
+    const result = highlightCode(code, "ts");
+    expect(result).toBe(code);
+  });
+
+  it("returns original code for unsupported extension", () => {
+    const code = "plain";
+    const result = highlightCode(code, "md");
+    expect(result).toBe(code);
+  });
+});

--- a/packages/code-explorer/src/utils/highlight.ts
+++ b/packages/code-explorer/src/utils/highlight.ts
@@ -1,0 +1,33 @@
+import Prism from "prismjs";
+import "prismjs/components/prism-typescript";
+import "prismjs/components/prism-javascript";
+import "prismjs/components/prism-jsx";
+import "prismjs/components/prism-tsx";
+
+/**
+{
+  "friendlyName": "highlight code",
+  "description": "Highlights source code using Prism based on file extension, with graceful fallback.",
+  "editCount": 1,
+  "tags": ["utility", "syntax"],
+  "location": "src/utils/highlight",
+  "notes": "Supports ts, tsx, js, jsx; returns raw code for unsupported types or on failure."
+}
+*/
+export function highlightCode(code: string, ext: string): string {
+  try {
+    const langMap: Record<string, string> = {
+      ts: "typescript",
+      tsx: "tsx",
+      js: "javascript",
+      jsx: "jsx",
+    };
+    const lang = langMap[ext];
+    if (!lang) return code;
+    const grammar = Prism.languages[lang];
+    if (!grammar) return code;
+    return Prism.highlight(code, grammar, lang);
+  } catch {
+    return code;
+  }
+}


### PR DESCRIPTION
## Summary
- add extension-aware `highlightCode` utility with Prism grammars
- use new highlighter in `FileViewer` to render selected files reliably
- document team profile workflow and add role markdown files

## Testing
- `npm test`
- `npx vitest run src/import-flow.test.tsx src/components/FileViewer.test.tsx src/utils/highlight.test.ts --root packages/code-explorer`


------
https://chatgpt.com/codex/tasks/task_e_68ba0eefe3b8833196363f274a009c15