### PR TITLE
docs: update team roster and product log

### DIFF
--- a/packages/code-explorer/Product_Manager-Ava_Wu.md
+++ b/packages/code-explorer/Product_Manager-Ava_Wu.md
@@ -41,7 +41,10 @@ Preparing the code explorer package for beta launch and refining remaining featu
 ## 🕒 Product Management Log
 ### Past
 - Reviewed team status and code base; planned upcoming tasks for canvas deletion, error handling, and documentation.
+- Reviewed team profiles and test suite; scoped tasks for resolving module resolution issues and improving docs.
 ### Current
 - Coordinating implementation of new features and ensuring cross-team communication remains smooth.
+- Coordinating fixes for failing tests and tracking research on function library architecture.
 ### Future
 - Preparing strategy for unified editing, dependency graph tooling, and real-time collaboration in future cycles.
+- Shaping roadmap for unified editing, dependency graph tooling, and eventual real-time collaboration once core stability is achieved.

--- a/packages/code-explorer/README.md
+++ b/packages/code-explorer/README.md
@@ -40,5 +40,6 @@ Current profiles:
 - [Frontend Developer — Simon Hesher](Frontend_Developer-Simon_Hesher.md)
 - [QA Engineer — Maria Li](QA_Engineer-Maria_Li.md)
 - [Documentation & Ops — Alex Kim](Documentation_Ops-Alex_Kim.md)
+- [Product Manager — Ava Wu](Product_Manager-Ava_Wu.md)
 
 These documents help the team coordinate work and keep project context in one place. Team members are responsible for keeping their profiles up to date.


### PR DESCRIPTION
## Summary
- add product manager profile to team roster
- extend product management log with latest planning notes

## Testing
- `npx vitest run --root .` *(fails: missing modules `@uiw/react-codemirror`, `diff`)*

------
https://chatgpt.com/codex/tasks/task_e_68ba582c25b0833197d3b2005ec28769