### PR TITLE
feat(code-explorer): lazy load codemirror languages

### DIFF
--- a/packages/code-explorer/src/components/FileViewer.test.tsx
+++ b/packages/code-explorer/src/components/FileViewer.test.tsx
@@ -2,7 +2,6 @@
 import React from "react";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { FileViewer } from "./FileViewer";
 
 const toast = vi.fn();
 
@@ -14,14 +13,33 @@ vi.mock("@/hooks/use-toast", () => ({
   useToast: () => ({ toast }),
 }));
 
+import { FileViewer, loadLanguageFromPath } from "./FileViewer";
+import { javascript } from "@codemirror/lang-javascript";
+
 const originalFetch = global.fetch;
 
 beforeEach(() => {
-  vi.restoreAllMocks();
+  vi.clearAllMocks();
 });
 
 afterEach(() => {
   global.fetch = originalFetch;
+});
+
+describe("loadLanguageFromPath", () => {
+  it("loads javascript module for ts files", async () => {
+    javascript.mockClear();
+    const exts = await loadLanguageFromPath("/repo/file.ts");
+    expect(javascript).toHaveBeenCalled();
+    expect(exts).toHaveLength(1);
+  });
+
+  it("falls back to plain text for unknown extensions", async () => {
+    javascript.mockClear();
+    const exts = await loadLanguageFromPath("/repo/file.unknown");
+    expect(javascript).not.toHaveBeenCalled();
+    expect(exts).toEqual([]);
+  });
 });
 
 describe("FileViewer", () => {

--- a/packages/code-explorer/test-stubs/codemirror.tsx
+++ b/packages/code-explorer/test-stubs/codemirror.tsx
@@ -1,0 +1,3 @@
+export default function CodeMirror(props: any) {
+  return <textarea data-testid="editor" {...props} />;
+}

--- a/packages/code-explorer/test-stubs/diff.ts
+++ b/packages/code-explorer/test-stubs/diff.ts
@@ -1,0 +1,8 @@
+export function createTwoFilesPatch(
+  _oldFile: string,
+  _newFile: string,
+  oldStr: string,
+  newStr: string
+): string {
+  return `--- a\n+++ b\n-${oldStr}\n+${newStr}`;
+}

--- a/packages/code-explorer/test-stubs/lang-css.ts
+++ b/packages/code-explorer/test-stubs/lang-css.ts
@@ -1,0 +1,2 @@
+import { vi } from "vitest";
+export const css = vi.fn(() => ({}));

--- a/packages/code-explorer/test-stubs/lang-html.ts
+++ b/packages/code-explorer/test-stubs/lang-html.ts
@@ -1,0 +1,2 @@
+import { vi } from "vitest";
+export const html = vi.fn(() => ({}));

--- a/packages/code-explorer/test-stubs/lang-javascript.ts
+++ b/packages/code-explorer/test-stubs/lang-javascript.ts
@@ -1,0 +1,2 @@
+import { vi } from "vitest";
+export const javascript = vi.fn(() => ({}));

--- a/packages/code-explorer/test-stubs/lang-json.ts
+++ b/packages/code-explorer/test-stubs/lang-json.ts
@@ -1,0 +1,2 @@
+import { vi } from "vitest";
+export const json = vi.fn(() => ({}));

--- a/packages/code-explorer/vitest.config.ts
+++ b/packages/code-explorer/vitest.config.ts
@@ -7,6 +7,24 @@ export default defineConfig({
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "../../client/src"),
+      "@uiw/react-codemirror": path.resolve(__dirname, "test-stubs/codemirror.tsx"),
+      diff: path.resolve(__dirname, "test-stubs/diff.ts"),
+      "@codemirror/lang-javascript": path.resolve(
+        __dirname,
+        "test-stubs/lang-javascript.ts"
+      ),
+      "@codemirror/lang-json": path.resolve(
+        __dirname,
+        "test-stubs/lang-json.ts"
+      ),
+      "@codemirror/lang-css": path.resolve(
+        __dirname,
+        "test-stubs/lang-css.ts"
+      ),
+      "@codemirror/lang-html": path.resolve(
+        __dirname,
+        "test-stubs/lang-html.ts"
+      ),
     },
   },
   test: {


### PR DESCRIPTION
## Summary
- lazy-load CodeMirror languages based on file path with graceful fallback to plain text
- test language inference and saving with stubbed CodeMirror modules

## Testing
- `npm test`
- `npx vitest run src/components/FileViewer.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68ba5b7fdb7c8331b8fe7b8bad6f19b7