### PR TITLE
feat: add tabbed file viewing

### DIFF
--- a/packages/code-explorer/src/App.test.tsx
+++ b/packages/code-explorer/src/App.test.tsx
@@ -1,9 +1,9 @@
 /* @vitest-environment jsdom */
 import React from "react";
-import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { render, screen, fireEvent, cleanup, within } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { CodeExplorerApp } from "./App";
-vi.mock("./components/FileViewer", () => ({ FileViewer: () => <div>viewer</div> }));
+vi.mock("./components/FileViewer", () => ({ FileViewer: ({ path }: any) => <div>{path}</div> }));
 vi.mock("./components/CompositionCanvas", () => ({ CompositionCanvas: () => <div /> }));
 
 vi.mock("prismjs", () => ({
@@ -61,6 +61,42 @@ describe("CodeExplorerApp", () => {
 
     // error path: invalid URL message
     expect(await screen.findByText("Please enter a valid GitHub URL")).toBeTruthy();
+  });
+
+  it("manages file tabs", async () => {
+    const tree = {
+      name: "repo",
+      path: "/repo",
+      children: [
+        { name: "one.ts", path: "/repo/one.ts" },
+        { name: "two.ts", path: "/repo/two.ts" },
+      ],
+    };
+    (global.fetch as any).mockResolvedValueOnce({ ok: true, json: async () => tree });
+
+    render(<CodeExplorerApp />);
+    fireEvent.click(screen.getAllByText("Import")[0]);
+    fireEvent.change(screen.getByPlaceholderText("https://github.com/user/repo"), {
+      target: { value: "https://github.com/user/repo" },
+    });
+    fireEvent.click(screen.getAllByText("Import")[1]);
+
+    await screen.findByText("one.ts");
+
+    fireEvent.click(screen.getByText("one.ts"));
+    expect(await screen.findByText("/repo/one.ts")).toBeTruthy();
+
+    fireEvent.click(screen.getByText("two.ts"));
+    expect(await screen.findByText("/repo/two.ts")).toBeTruthy();
+
+    const tabBar = screen.getByTestId("tab-bar");
+    fireEvent.click(within(tabBar).getByText("one.ts"));
+    expect(await screen.findByText("/repo/one.ts")).toBeTruthy();
+
+    const closeBtns = within(tabBar).getAllByLabelText("Close");
+    fireEvent.click(closeBtns[1]);
+    expect(within(tabBar).getAllByLabelText("Close").length).toBe(1);
+    expect(await screen.findByText("/repo/one.ts")).toBeTruthy();
   });
 });
 

--- a/packages/code-explorer/src/components/FileViewer.tsx
+++ b/packages/code-explorer/src/components/FileViewer.tsx
@@ -72,6 +72,8 @@ export function FileViewer({ path }: Props) {
     }
     */
     async function load() {
+      setCode("");
+      setOriginal("");
       const res = await fetch(`/code-explorer/api/file?path=${encodeURIComponent(path)}`);
       const text = await res.text();
       setCode(text);

--- a/packages/code-explorer/test-stubs/react-virtualized.tsx
+++ b/packages/code-explorer/test-stubs/react-virtualized.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+export const List = ({ rowRenderer, rowCount }: any) => (
+  <div>{Array.from({ length: rowCount }).map((_, i) => rowRenderer({ index: i, key: i, style: {} }))}</div>
+);
+export default { List };

--- a/packages/code-explorer/vitest.config.ts
+++ b/packages/code-explorer/vitest.config.ts
@@ -25,6 +25,10 @@ export default defineConfig({
         __dirname,
         "test-stubs/lang-html.ts"
       ),
+      "react-virtualized": path.resolve(
+        __dirname,
+        "test-stubs/react-virtualized.tsx"
+      ),
     },
   },
   test: {


### PR DESCRIPTION
## Summary
- support multiple open files using tabbed interface
- reset code viewer when switching files
- add tests for tab management and viewer reload

## Testing
- `npm test -- -c packages/code-explorer/vitest.config.ts packages/code-explorer/src/components/FileViewer.test.tsx packages/code-explorer/src/App.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68bb153601b48331ada444714a5e88cb