### PR TITLE
test: cover missing syntax module

### DIFF
--- a/packages/code-explorer/QA_Engineer-Maria_Li.md
+++ b/packages/code-explorer/QA_Engineer-Maria_Li.md
@@ -23,6 +23,7 @@ Prioritizing regression tests for large directory scans with nested symlinks and
 
 ## 📝 Current Task Notes
 - Preparing test fixtures for nested symlink directories and extensionless files.
+- Added fixtures to emulate missing syntax modules and verify FileViewer warnings.
 
 ## 🗂️ Project Notes
 - Completed review of recent bug reports to design targeted tests.

--- a/packages/code-explorer/__tests__/fixtures/missingLang.ts
+++ b/packages/code-explorer/__tests__/fixtures/missingLang.ts
@@ -1,0 +1,6 @@
+import { vi } from "vitest";
+
+// Simulate a missing CodeMirror language module by throwing on import.
+vi.mock("@codemirror/lang-javascript", () => {
+  throw new Error("Cannot find module '@codemirror/lang-javascript'");
+});

--- a/packages/code-explorer/__tests__/viewer-missing-module.test.tsx
+++ b/packages/code-explorer/__tests__/viewer-missing-module.test.tsx
@@ -1,0 +1,39 @@
+/* @vitest-environment jsdom */
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+
+// Mock UI components and toast used by FileViewer
+vi.mock("@/components/ui/button", () => ({
+  Button: (props: any) => <button {...props} />,
+}));
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+// Import fixture that mocks missing language module
+import "./fixtures/missingLang";
+
+import { FileViewer } from "../src/components/FileViewer";
+
+describe("FileViewer missing language module", () => {
+  it("renders raw text and warns when module is missing", async () => {
+    const source = "const a = 1;";
+    const originalFetch = global.fetch;
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue({ ok: true, text: async () => source }) as any;
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    render(<FileViewer path="/repo/test.ts" />);
+
+    const textarea = await screen.findByTestId("editor");
+    expect((textarea as HTMLTextAreaElement).value).toBe(source);
+    expect(textarea.getAttribute("extensions")).toBeNull();
+
+    await waitFor(() => expect(warn).toHaveBeenCalled());
+
+    warn.mockRestore();
+    global.fetch = originalFetch;
+  });
+});

--- a/packages/code-explorer/src/components/FileViewer.tsx
+++ b/packages/code-explorer/src/components/FileViewer.tsx
@@ -48,7 +48,11 @@ export async function loadLanguageFromPath(path: string): Promise<Extension[]> {
   try {
     const lang = await loaders[ext ?? ""]?.();
     return lang ? [lang] : [];
-  } catch {
+  } catch (err) {
+    console.warn(
+      `Failed to load language module for "${ext}". Rendering as plain text.`,
+      err
+    );
     return [];
   }
 }


### PR DESCRIPTION
## Summary
- warn when a language module can't be loaded and fall back to plain text
- add fixture and test for FileViewer behavior when syntax module is missing
- document missing-module scenario in QA notes

## Testing
- `npx vitest run --config packages/code-explorer/vitest.config.ts` *(fails: applyPatch is not a function; FileTree virtualization assertion)*
- `npx vitest run --config packages/code-explorer/vitest.config.ts packages/code-explorer/__tests__/viewer-missing-module.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bb1952105c83318149d0a7f9e23cea