### PR TITLE
fix: import diff applyPatch correctly

### DIFF
--- a/packages/code-explorer/test-stubs/diff.ts
+++ b/packages/code-explorer/test-stubs/diff.ts
@@ -6,3 +6,16 @@ export function createTwoFilesPatch(
 ): string {
   return `--- a\n+++ b\n-${oldStr}\n+${newStr}`;
 }
+
+export function applyPatch(original: string, patch: string): string | false {
+  const lines = patch.split("\n");
+  const removeLine = lines
+    .find((line) => line.startsWith("-") && !line.startsWith("---"))
+    ?.slice(1);
+  const addLine = lines
+    .find((line) => line.startsWith("+") && !line.startsWith("+++"))
+    ?.slice(1);
+  if (!removeLine || !addLine) return false;
+  if (!original.includes(removeLine)) return false;
+  return original.replace(removeLine, addLine);
+}

--- a/server/save.ts
+++ b/server/save.ts
@@ -1,5 +1,5 @@
 import fs from "fs/promises";
-import { applyPatch } from "diff";
+import * as Diff from "diff";
 
 /**
  * Applies a unified diff patch to a file on disk.
@@ -7,7 +7,7 @@ import { applyPatch } from "diff";
  */
 export async function applyPatchToFile(filePath: string, patch: string): Promise<void> {
   const original = await fs.readFile(filePath, "utf8");
-  const updated = applyPatch(original, patch);
+  const updated = Diff.applyPatch(original, patch);
   if (updated === false) {
     throw new Error("Patch failed");
   }


### PR DESCRIPTION
## Summary
- import `applyPatch` via namespace import to handle CommonJS `diff` package
- add minimal `applyPatch` implementation to `diff` test stub

## Testing
- `npx vitest run --config packages/code-explorer/vitest.config.ts packages/code-explorer/__tests__/save.test.ts`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb1cc5b4f88331b3bdf77cedf5c6cb