### PR TITLE
test: ensure FileTree virtualization under JSDOM

### DIFF
--- a/packages/code-explorer/vitest.config.ts
+++ b/packages/code-explorer/vitest.config.ts
@@ -25,10 +25,6 @@ export default defineConfig({
         __dirname,
         "test-stubs/lang-html.ts"
       ),
-      "react-virtualized": path.resolve(
-        __dirname,
-        "test-stubs/react-virtualized.tsx"
-      ),
     },
   },
   test: {


### PR DESCRIPTION
## Summary
- run FileTree tests against real `react-virtualized` List by dropping test stub
- mock element dimensions in FileTree test and assert only a few nodes render

## Testing
- `npx vitest run src/components/FileTree.test.tsx`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb1e8115f0833199d63d176ca34a2f