### PR TITLE
chore: update Playwright dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -94,8 +94,8 @@
         "zod-validation-error": "^3.4.0"
       },
       "devDependencies": {
-        "@playwright/experimental-ct-react": "^1.48.2",
-        "@playwright/test": "^1.48.2",
+        "@playwright/experimental-ct-react": "^1.55.0",
+        "@playwright/test": "^1.55.0",
         "@replit/vite-plugin-cartographer": "^0.2.8",
         "@replit/vite-plugin-runtime-error-modal": "^0.0.3",
         "@tailwindcss/typography": "^0.5.15",
@@ -118,6 +118,7 @@
         "esbuild": "^0.25.0",
         "jsdom": "^24.0.0",
         "open": "^10.2.0",
+        "playwright": "^1.55.0",
         "postcss": "^8.4.47",
         "tailwindcss": "^3.4.17",
         "tsx": "^4.19.1",

--- a/package.json
+++ b/package.json
@@ -99,8 +99,9 @@
     "zod-validation-error": "^3.4.0"
   },
   "devDependencies": {
-    "@playwright/experimental-ct-react": "^1.48.2",
-    "@playwright/test": "^1.48.2",
+    "@playwright/experimental-ct-react": "^1.55.0",
+    "@playwright/test": "^1.55.0",
+    "playwright": "^1.55.0",
     "@replit/vite-plugin-cartographer": "^0.2.8",
     "@replit/vite-plugin-runtime-error-modal": "^0.0.3",
     "@tailwindcss/typography": "^0.5.15",


### PR DESCRIPTION
## Summary
- upgrade Playwright test packages to `^1.55.0`
- add explicit `playwright` dependency to expose CLI

## Testing
- `npm run test:playwright` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/...)*

------
https://chatgpt.com/codex/tasks/task_e_68bb2394d7d4833185bacc9041607896