### PR TITLE
test: mock FileViewer network requests

### DIFF
--- a/packages/code-explorer/e2e/fileviewer.spec.tsx
+++ b/packages/code-explorer/e2e/fileviewer.spec.tsx
@@ -4,11 +4,11 @@ import { FileViewer } from '../src/components/FileViewer';
 
 test.describe('FileViewer', () => {
   test('saves patched content', async ({ mount, page }) => {
-    await page.route('/code-explorer/api/file?*', route =>
+    await page.route('**/code-explorer/api/file?*', route =>
       route.fulfill({ body: 'const a = 1;' })
     );
     let saveRequest;
-    await page.route('/code-explorer/api/save', route => {
+    await page.route('**/code-explorer/api/save', route => {
       saveRequest = route.request();
       route.fulfill({ status: 200, body: '{}' });
     });
@@ -22,10 +22,10 @@ test.describe('FileViewer', () => {
   });
 
   test('toggles fullscreen via control', async ({ mount, page }) => {
-    await page.route('/code-explorer/api/file?*', route =>
+    await page.route('**/code-explorer/api/file?*', route =>
       route.fulfill({ body: 'const a = 1;' })
     );
-    await page.route('/code-explorer/api/save', route =>
+    await page.route('**/code-explorer/api/save', route =>
       route.fulfill({ status: 200, body: '{}' })
     );
     await mount(<FileViewer path="/repo/test.ts" />);


### PR DESCRIPTION
## Summary
- ensure Playwright tests intercept `/code-explorer` API calls before mounting FileViewer

## Testing
- `npx playwright test packages/code-explorer/e2e/fileviewer.spec.tsx --debug` *(fails: browserType.launch: Target page, context or browser has been closed)*

------
https://chatgpt.com/codex/tasks/task_e_68bb24491ed08331b87c8dad40fd092b