### PR TITLE
feat(code-explorer): add changelog generator script

### DIFF
--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1,0 +1,11 @@
+# Runbook
+
+## Generate changelog
+
+Use the changelog script to create Markdown release notes from conventional commit messages.
+
+```bash
+node packages/code-explorer/scripts/generate-changelog.js CHANGELOG.md
+```
+
+The script inspects git tags in chronological order, groups commits by type, and writes the resulting changelog to the specified file. If no file path is provided, the output is printed to standard output.

--- a/packages/code-explorer/scripts/generate-changelog.js
+++ b/packages/code-explorer/scripts/generate-changelog.js
@@ -1,0 +1,96 @@
+import { execSync } from 'node:child_process';
+import { writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const typeMap = {
+  feat: 'Features',
+  fix: 'Bug Fixes',
+  docs: 'Documentation',
+  chore: 'Chores',
+  refactor: 'Refactors',
+  test: 'Tests',
+  build: 'Build System',
+  ci: 'CI',
+  perf: 'Performance',
+  style: 'Styles',
+  other: 'Other',
+};
+
+function getTags() {
+  try {
+    const tags = execSync('git tag --sort=creatordate', { encoding: 'utf8' })
+      .split('\n')
+      .map(t => t.trim())
+      .filter(Boolean);
+    return tags;
+  } catch (err) {
+    console.error('Failed to list git tags');
+    return [];
+  }
+}
+
+function getCommits(from, to) {
+  const range = from ? `${from}..${to}` : to;
+  try {
+    const commits = execSync(`git log --format=%s ${range}`, { encoding: 'utf8' })
+      .split('\n')
+      .map(c => c.trim())
+      .filter(Boolean);
+    return commits;
+  } catch {
+    return [];
+  }
+}
+
+function parseCommit(message) {
+  const match = message.match(/^(\w+)(?:\([^)]+\))?:\s*(.+)$/);
+  if (match) {
+    return { type: match[1], description: match[2] };
+  }
+  return { type: 'other', description: message };
+}
+
+function groupCommits(commits) {
+  const groups = {};
+  for (const msg of commits) {
+    const { type, description } = parseCommit(msg);
+    const section = typeMap[type] || type;
+    groups[section] = groups[section] || [];
+    groups[section].push(description);
+  }
+  return groups;
+}
+
+function buildMarkdown() {
+  const tags = getTags();
+  const sections = [];
+  for (let i = 0; i < tags.length; i++) {
+    const to = tags[i];
+    const from = tags[i - 1];
+    const commits = getCommits(from, to);
+    if (commits.length === 0) continue;
+    const groups = groupCommits(commits);
+    let md = `## ${to}\n\n`;
+    for (const [section, items] of Object.entries(groups)) {
+      md += `### ${section}\n`;
+      for (const item of items) {
+        md += `- ${item}\n`;
+      }
+      md += '\n';
+    }
+    sections.push(md.trim());
+  }
+  return sections.join('\n\n');
+}
+
+function main() {
+  const markdown = buildMarkdown();
+  const outFile = process.argv[2];
+  if (outFile) {
+    writeFileSync(resolve(outFile), markdown);
+  } else {
+    console.log(markdown);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- add script to parse conventional commits and build markdown changelogs
- document changelog generation in runbook

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb2473aa308331ac7556ae90f4085e