### PR TITLE
docs: add onboarding guide and maintenance plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Mining Syndicate Platform
 
+See [Onboarding Guide](docs/onboarding.md) for setup, tests, and profile conventions.
+
 ## Development
 
 - **Full application**: `npm run dev`

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -1,0 +1,42 @@
+# Onboarding Guide
+
+This guide covers setting up the project locally, running tests, and establishing profile conventions for contributors.
+
+## Setup
+
+1. **Clone the repository**
+   ```bash
+   git clone <repo-url>
+   cd mining-syndicate-platform
+   ```
+2. **Install dependencies**
+   ```bash
+   npm install
+   ```
+3. **Start the development servers**
+   ```bash
+   npm run dev
+   ```
+   Visit `http://localhost:5000` to view the app.
+
+## Running Tests
+
+- **Full test suite**
+  ```bash
+  npm test
+  ```
+- **Targeted tests**
+  ```bash
+  npx vitest path/to/testfile.ts
+  ```
+
+## Profile Conventions
+
+- Use your real name and preferred pronouns in documentation.
+- Configure Git with your name and email:
+  ```bash
+  git config user.name "Your Name"
+  git config user.email "you@example.com"
+  ```
+- Follow conventional commit messages (e.g., `feat: add feature`, `fix: resolve bug`).
+

--- a/packages/code-explorer/Documentation_Ops-Alex_Kim.md
+++ b/packages/code-explorer/Documentation_Ops-Alex_Kim.md
@@ -34,3 +34,9 @@ Standardize repository documentation and automate release notes.
 
 ## 🚨 Urgent Notes
 
+
+## 🔧 Maintenance Plan
+- Review documentation monthly for accuracy.
+- Audit CI pipelines quarterly.
+- Rotate credentials and update contact list each release.
+


### PR DESCRIPTION
## Summary
- add onboarding guide covering setup, testing, and profile conventions
- link onboarding guide from main README
- outline maintenance plan for Documentation & Ops profile

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb2595f5748331a149ef861c4bf3db