### PR TITLE
Handle CodeMirror load failures with plain text fallback

### DIFF
--- a/packages/code-explorer/src/components/FileViewer.test.tsx
+++ b/packages/code-explorer/src/components/FileViewer.test.tsx
@@ -128,4 +128,26 @@ describe("FileViewer", () => {
 
     window.removeEventListener("keydown", blocker);
   });
+
+  it("renders raw code when CodeMirror fails to load", async () => {
+    const source = "const a = 1;";
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: true, text: async () => source });
+    global.fetch = fetchMock as any;
+
+    vi.resetModules();
+    vi.doMock("@uiw/react-codemirror", () => {
+      throw new Error("failed import");
+    });
+
+    const { FileViewer: FallbackViewer } = await import("./FileViewer");
+
+    render(<FallbackViewer path="/repo/test.ts" />);
+    const pre = await screen.findByTestId("raw-code");
+    expect(pre.textContent).toBe(source);
+
+    vi.unmock("@uiw/react-codemirror");
+    vi.resetModules();
+  });
 });

--- a/packages/code-explorer/src/components/FileViewer.tsx
+++ b/packages/code-explorer/src/components/FileViewer.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useEffect, useState } from "react";
-import CodeMirror from "@uiw/react-codemirror";
 import type { Extension } from "@codemirror/state";
 import { createTwoFilesPatch } from "diff";
 import { Button } from "@/components/ui/button";
@@ -62,7 +61,22 @@ export function FileViewer({ path }: Props) {
   const [original, setOriginal] = useState("");
   const [fullscreen, setFullscreen] = useState(false);
   const [extensions, setExtensions] = useState<Extension[]>([]);
+  const [CodeMirror, setCodeMirror] = useState<React.ComponentType<any> | null>(
+    null
+  );
   const { toast } = useToast();
+
+  useEffect(() => {
+    import("@uiw/react-codemirror")
+      .then((m) => setCodeMirror(() => m.default))
+      .catch((err) => {
+        console.warn(
+          "Failed to load CodeMirror. Rendering plain text instead.",
+          err
+        );
+        setCodeMirror(null);
+      });
+  }, []);
 
   useEffect(() => {
     /**
@@ -150,12 +164,22 @@ export function FileViewer({ path }: Props) {
         </Button>
       </div>
       <div className="overflow-auto h-full border rounded">
-        <CodeMirror
-          value={code}
-          height="100%"
-          extensions={extensions}
-          onChange={(value) => setCode(value)}
-        />
+        {CodeMirror ? (
+          <CodeMirror
+            value={code}
+            height="100%"
+            extensions={extensions}
+            onChange={(value: any) =>
+              setCode(
+                typeof value === "string" ? value : value?.target?.value ?? ""
+              )
+            }
+          />
+        ) : (
+          <pre className="p-2" data-testid="raw-code">
+            {code}
+          </pre>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Dynamically import CodeMirror and warn on failures
- Render raw `<pre>` fallback when CodeMirror isn't available
- Test CodeMirror failure path and ensure existing editor tests work

## Testing
- `npx vitest run src/components/FileViewer.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bb294cd5348331b1f180580e0177f0