### PR TITLE
chore: add pre-commit persona profile check

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "check": "tsc",
     "test": "vitest run",
     "test:playwright": "playwright test",
-    "db:push": "drizzle-kit push"
+    "db:push": "drizzle-kit push",
+    "pre-commit": "node scripts/check-persona-updates.js"
   },
   "dependencies": {
     "@codemirror/lang-javascript": "^6.2.1",

--- a/scripts/check-persona-updates.js
+++ b/scripts/check-persona-updates.js
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+import { execSync } from 'child_process';
+
+function getStagedFiles() {
+  const output = execSync('git diff --cached --name-only', { encoding: 'utf8' });
+  return output.split('\n').map(f => f.trim()).filter(Boolean);
+}
+
+const userName = execSync('git config user.name', { encoding: 'utf8' }).trim();
+const sanitizedName = userName.replace(/\s+/g, '_');
+const profileRegex = new RegExp(`.*-${sanitizedName}\\.md$`);
+
+const stagedFiles = getStagedFiles();
+const touchesCodeExplorer = stagedFiles.some(f => f.startsWith('packages/code-explorer/src'));
+const touchesTests = stagedFiles.some(f => f.includes('__tests__'));
+
+if (!touchesCodeExplorer && !touchesTests) {
+  process.exit(0);
+}
+
+const hasProfileUpdate = stagedFiles.some(f => profileRegex.test(f));
+
+if (!hasProfileUpdate) {
+  console.error(
+    `Error: commits touching packages/code-explorer/src or __tests__ must include a *-${sanitizedName}.md profile update.`
+  );
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- add pre-commit script to ensure persona profile is updated when editing code or tests
- wire the profile check into package.json

## Testing
- `npm test`
- `node scripts/check-persona-updates.js`


------
https://chatgpt.com/codex/tasks/task_e_68bb2c23b41c8331ad02618570dfeb3e