### PR TITLE
docs: add Card Builder README

### DIFF
--- a/packages/card-builder/README.md
+++ b/packages/card-builder/README.md
@@ -1,0 +1,14 @@
+# Card Builder
+
+## Project Goals and Scope
+- Provide a drag-and-drop interface for assembling card UI components from predefined data elements.
+- Offer real-time preview and a code view for editing the underlying JSON or React component.
+- Allow designers to style cards with selectable themes, shadows, lighting effects, and animations.
+- Export completed card definitions as JSON for integration into the Mining Syndicate platform.
+
+## Team Roster
+- [Tech Lead — Jordan Rowe](../code-explorer/Tech_Lead-Jordan_Rowe.md)
+- [Product Manager — Ava Wu](../code-explorer/Product_Manager-Ava_Wu.md)
+- [Frontend Developer — Simon Hesher](../code-explorer/Frontend_Developer-Simon_Hesher.md)
+- [Documentation Ops — Alex Kim](../code-explorer/Documentation_Ops-Alex_Kim.md)
+- [QA Engineer — Maria Li](../code-explorer/QA_Engineer-Maria_Li.md)


### PR DESCRIPTION
## Summary
- document Card Builder project goals and scope
- add team roster with links to persona files

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb2e880ee8833190377a790de916bc