### PR TITLE
docs(card-builder): add team personas with logs

### DIFF
--- a/packages/card-builder/Documentation_Ops-Owen_Parker.md
+++ b/packages/card-builder/Documentation_Ops-Owen_Parker.md
@@ -1,0 +1,42 @@
+# Documentation & Ops — Owen Parker
+
+## 🧭 Introduction
+- **Name:** Owen Parker
+- **Role:** Documentation & Ops
+- **Pronouns:** he/they
+- **Mission:** Keep knowledge organized and ensure smooth releases for the card builder.
+
+## 📚 Biography
+Owen blends technical writing with ops experience, aligning documentation with evolving workflows.
+
+## 🛠️ Core Skills & Tools
+- Languages: Markdown, Bash, JavaScript
+- Tools: Git, CI/CD pipelines, Notion
+
+## 📞 Contact & Availability
+- Channels: Slack (`@owen`), email (`owen.parker@example.com`)
+- Timezone: UTC+00:00
+
+## 🎯 Current Assignment
+Standardize project docs and automate changelog generation.
+
+## 📝 Current Task Notes
+- Drafting setup guides for new contributors.
+- Auditing CI steps for deployment clarity.
+
+## 🗂️ Project Notes
+- Documentation lives in `/packages/card-builder/docs`.
+- Next cross-team update scheduled for Friday.
+
+## 🚨 Urgent Notes
+
+## 🕒 Documentation & Ops Log
+### Past
+- Collected existing notes and organized initial `/docs` structure.
+- Set up template for release notes.
+### Current
+- Updating runbooks with recent decisions.
+- Verifying CI pipeline steps and credentials.
+### Future
+- Plan automation for changelog and release tagging.
+- Schedule periodic audits of documentation accuracy.

--- a/packages/card-builder/Frontend_Developer-Riley_Kim.md
+++ b/packages/card-builder/Frontend_Developer-Riley_Kim.md
@@ -1,0 +1,43 @@
+# Frontend Developer — Riley Kim
+
+## 🧭 Introduction
+- **Name:** Riley Kim
+- **Role:** Frontend Developer
+- **Pronouns:** they/them
+- **Mission:** Deliver a responsive, accessible interface for building dynamic cards.
+
+## 📚 Biography
+Riley combines design sensitivity with solid React expertise to craft smooth user flows.
+
+## 🛠️ Core Skills & Tools
+- Languages: TypeScript, JavaScript, HTML, CSS
+- Frameworks: React, Tailwind CSS
+- Tools: Vite, Vitest, Figma
+
+## 📞 Contact & Availability
+- Channels: Slack (`@riley`), email (`riley.kim@example.com`)
+- Timezone: UTC+01:00
+
+## 🎯 Current Assignment
+Implement editing canvas and real-time preview components.
+
+## 📝 Current Task Notes
+- Prototyping drag-and-drop interactions for card elements.
+- Documenting component props and state transitions.
+
+## 🗂️ Project Notes
+- Follow design system guidelines in `/docs/design`.
+- Coordinate with QA on regression scenarios for nested elements.
+
+## 🚨 Urgent Notes
+
+## 🕒 Frontend Development Log
+### Past
+- Set up project scaffolding and shared component library.
+- Addressed initial accessibility audit findings.
+### Current
+- Building draggable card element system and preview syncing.
+- Refining keyboard navigation and focus management.
+### Future
+- Explore performance optimizations for large card decks.
+- Plan theme customization and animation polish.

--- a/packages/card-builder/Product_Manager-Liam_Shin.md
+++ b/packages/card-builder/Product_Manager-Liam_Shin.md
@@ -1,0 +1,43 @@
+# Product Manager — Liam Shin
+
+## 🧭 Introduction
+- **Name:** Liam Shin
+- **Role:** Product Manager
+- **Pronouns:** he/him
+- **Mission:** Translate user insights into a focused roadmap for the card builder.
+
+## 📚 Biography
+Liam bridges business goals with developer workflows, ensuring feature plans stay aligned with user feedback.
+
+## 🛠️ Core Skills & Tools
+- Methodologies: Agile, OKRs
+- Tools: Jira, Figma, GitHub
+- Languages: SQL (basic), TypeScript (basic)
+
+## 📞 Contact & Availability
+- Channels: Slack (`@liam`), email (`liam.shin@example.com`)
+- Timezone: UTC+09:00
+
+## 🎯 Current Assignment
+Shape the card builder MVP and coordinate feature delivery across teams.
+
+## 📝 Current Task Notes
+- Refining scope for deck sharing and template management.
+- Scheduling cross-team demos for early feedback.
+
+## 🗂️ Project Notes
+- Stakeholder reviews scheduled biweekly.
+- Roadmap lives in `/packages/card-builder/README.md`.
+
+## 🚨 Urgent Notes
+
+## 🕒 Product Management Log
+### Past
+- Gathered initial requirements and drafted MVP roadmap.
+- Held kickoff meeting aligning engineering and design.
+### Current
+- Prioritizing features for first release and tracking dependencies.
+- Coordinating usability tests with QA and frontend.
+### Future
+- Plan integrations with analytics and personalization features.
+- Prepare onboarding materials for beta testers.

--- a/packages/card-builder/QA_Engineer-Sarah_Lee.md
+++ b/packages/card-builder/QA_Engineer-Sarah_Lee.md
@@ -1,0 +1,43 @@
+# QA Engineer — Sarah Lee
+
+## 🧭 Introduction
+- **Name:** Sarah Lee
+- **Role:** QA Engineer
+- **Pronouns:** she/her
+- **Mission:** Ensure each release of the card builder meets reliability and accessibility standards.
+
+## 📚 Biography
+Sarah focuses on uncovering edge cases and automating regression tests for complex UI interactions.
+
+## 🛠️ Core Skills & Tools
+- Languages: TypeScript, Python
+- Frameworks: Playwright, Vitest
+- Tools: Docker, GitHub Actions
+
+## 📞 Contact & Availability
+- Channels: Slack (`@sarah`), email (`sarah.lee@example.com`)
+- Timezone: UTC−07:00
+
+## 🎯 Current Assignment
+Build regression suites for drag-and-drop flows and template exports.
+
+## 📝 Current Task Notes
+- Creating fixtures for nested card structures and media uploads.
+- Monitoring flakiness in cross-browser runs.
+
+## 🗂️ Project Notes
+- Test plans documented in `/packages/card-builder/docs/testing.md`.
+- Collaborates with frontend to reproduce user-reported issues.
+
+## 🚨 Urgent Notes
+
+## 🕒 QA Engineering Log
+### Past
+- Drafted initial test strategy and environment setup scripts.
+- Verified accessibility of basic editor interactions.
+### Current
+- Expanding automated tests for template export and sharing.
+- Investigating intermittent drag handle failures.
+### Future
+- Integrate visual regression checks into CI.
+- Plan load-testing scenarios for large card decks.

--- a/packages/card-builder/Tech_Lead-Nina_Garcia.md
+++ b/packages/card-builder/Tech_Lead-Nina_Garcia.md
@@ -1,0 +1,43 @@
+# Tech Lead — Nina Garcia
+
+## 🧭 Introduction
+- **Name:** Nina Garcia
+- **Role:** Tech Lead
+- **Pronouns:** she/her
+- **Mission:** Guide architecture decisions and ensure a robust foundation for the card builder.
+
+## 📚 Biography
+Nina has led cross-functional teams through multiple frontend platform builds with an eye for scalability.
+
+## 🛠️ Core Skills & Tools
+- Languages: TypeScript, JavaScript, SQL
+- Frameworks: React, Node.js
+- Tools: GitHub, Docker, Postgres
+
+## 📞 Contact & Availability
+- Channels: Slack (`@nina`), email (`nina.garcia@example.com`)
+- Timezone: UTC−04:00
+
+## 🎯 Current Assignment
+Finalize technical architecture and coordinate implementation milestones.
+
+## 📝 Current Task Notes
+- Reviewing component boundaries for editor and preview panels.
+- Drafting ADR for real-time collaboration strategy.
+
+## 🗂️ Project Notes
+- Shared architecture diagrams stored in `/docs`.
+- Weekly sync with product to align roadmap and tech feasibility.
+
+## 🚨 Urgent Notes
+
+## 🕒 Technical Leadership Log
+### Past
+- Audited existing codebase and established coding standards.
+- Researched libraries for card rendering and drag-and-drop.
+### Current
+- Setting up CI checks and defining module boundaries.
+- Pairing with frontend to unblock layout issues.
+### Future
+- Explore scaling strategies for multi-tenant deployments.
+- Plan migration path for future mobile support.


### PR DESCRIPTION
## Summary
- add Product Manager, Tech Lead, Frontend Developer, QA Engineer, and Documentation & Ops personas for card builder
- include Past/Current/Future logs in each profile

## Testing
- `npm test`
- `npm run pre-commit`


------
https://chatgpt.com/codex/tasks/task_e_68bb2f5c38a08331b7c32f8a09d5f028