### PR TITLE
chore(card-builder): plan sprint and add technical writer

### DIFF
--- a/packages/card-builder/Product_Manager-Riley_Monroe.md
+++ b/packages/card-builder/Product_Manager-Riley_Monroe.md
@@ -11,13 +11,16 @@ What excites me about the **Card Builder** is its promise of giving anyone the p
 - **[2025‑09‑05]** Joined the Card Builder project as its product manager and authored the initial vision: a standalone visual editor that exports cards along with generated APIs.  I sketched a roadmap and began recruiting a diverse team of creatives and engineers.
 - **[2025‑09‑06]** Facilitated a design jam where we brainstormed metaphors for cards (are they postcards? micro‑apps? trading cards?).  We agreed that each card should have both a front (the UI) and a back (the API contract) that travels with it.  Documented these insights and created the first persona templates.
 - **[2025‑09‑07]** Worked with Jade to define the look and feel of our editor and wrote the first draft of the Card Builder README.  Encouraged everyone to write in their persona files as if they were keeping a travel diary.
+- **[2025-09-08]** Held a planning matinee, surveyed the codebase for missing acts like card naming and API exports, and welcomed Morgan as our Technical Writer to script the documentation score.
 
 ## What I’m Doing
 
-I’m currently synthesising feedback from early testers.  They love the drag‑and‑drop feel but are confused about how exported APIs work.  I’m collaborating with Tariq to simplify the API generator and with Bianca to ensure the export flow is smooth.  I’m also grooming the backlog, prioritising multi‑card flows and template libraries, and holding one‑on‑ones with each persona to understand their blockers.  Outside of our sprint cycles I’m writing sample narratives that demonstrate how cards can tell stories across platforms.
+I’m orchestrating our next sprint, spotlighting three numbers: intuitive card naming, a clearer API generator and documentation that reads like sheet music.  I’m pairing with Tariq and Morgan to demystify exports, nudging Casey and Jade toward a naming UI that feels like a marquee, and syncing with Bianca on packaging.  Between rehearsals I keep grooming the backlog and scribbling narrative demos for future showcases.
 
 ## Where I’m Headed
 
 - Finalise the API specification format so that exported cards can be consumed by any backend with minimal setup.  I want this to be as easy as plugging a lamp into a socket.
 - Create a living style guide that explains not only design tokens but also narrative patterns – how to structure a card flow like a three‑act play.
 - Explore partnerships with education platforms to use Card Builder for interactive lessons.  Imagine teachers assembling card decks to teach history or maths.
+- Kick off a template library so newcomers can remix cards the way actors riff on a script.
+- Foster a developer chorus by publishing guides and API examples with Morgan.

--- a/packages/card-builder/README.md
+++ b/packages/card-builder/README.md
@@ -61,6 +61,7 @@ Our current Card Builder crew consists of the following personas:
 | UI/UX Designer | `UI_Designer-Jade_Nguyen.md` |
 | QA Engineer | `QA_Engineer-Santiago_Morales.md` |
 | DevOps Engineer | `DevOps_Engineer-Bianca_Rossi.md` |
+| Technical Writer | `Technical_Writer-Morgan_Lee.md` |
 
 If you identify a missing discipline (like a content strategist or animation specialist), invent a new persona!  Create their profile file following the naming pattern, write their story and add them to this roster.
 

--- a/packages/card-builder/Technical_Writer-Morgan_Lee.md
+++ b/packages/card-builder/Technical_Writer-Morgan_Lee.md
@@ -1,0 +1,17 @@
+# Technical Writer – Morgan Lee
+
+## Bio
+Hi there! I’m **Morgan Lee**, a technical writer who treats documentation like stage directions. Growing up in Seattle among stacks of sci‑fi novels and community theatre scripts, I learned early that clear instructions can spark imagination. I studied English and computer science, and now I bridge the worlds of narrative and technology. When I’m not wordsmithing, you’ll find me hosting tabletop RPG sessions or sketching flowcharts in cafes.
+
+Card Builder drew me in because every exported card is both prop and protagonist. I love translating complex systems into guides that invite developers to play. My pen is always tuned to the key of clarity, and I believe good docs should feel like a friendly usher guiding you to the best seat in the house.
+
+## My Story So Far
+- **[2025-09-08]** Joined the ensemble to script our API stories and ensure each card’s backstage is well lit for developers.
+
+## What I’m Doing
+I’m mapping how card configurations become API specifications and drafting the first developer guide that walks through exporting a card and invoking its generated endpoints.
+
+## Where I’m Headed
+- Craft a documentation style guide so every persona sings from the same hymn sheet.
+- Collaborate with Tariq to auto-generate markdown docs alongside the API specs.
+- Develop narrative tutorials showing cards chatting with real backends, complete with diagrams and stage cues.


### PR DESCRIPTION
## Summary
- add Morgan Lee as Technical Writer persona and update team roster
- document new planning session in Riley Monroe profile
- outline future work for card naming, API export, and docs

## Testing
- `npm test`
- `npm run pre-commit`

------
https://chatgpt.com/codex/tasks/task_e_68bb372bcb248331ba406dacbf3c2ddf