### PR TITLE
feat: fallback to raw viewer when language fails

### DIFF
--- a/packages/code-explorer/src/components/FileViewer.test.tsx
+++ b/packages/code-explorer/src/components/FileViewer.test.tsx
@@ -38,6 +38,7 @@ describe("loadLanguageFromPath", () => {
     javascript.mockClear();
     const exts = await loadLanguageFromPath("/repo/file.ts");
     expect(javascript).toHaveBeenCalled();
+    expect(exts).not.toBeNull();
     expect(exts).toHaveLength(1);
   });
 
@@ -45,7 +46,7 @@ describe("loadLanguageFromPath", () => {
     javascript.mockClear();
     const exts = await loadLanguageFromPath("/repo/file.unknown");
     expect(javascript).not.toHaveBeenCalled();
-    expect(exts).toEqual([]);
+    expect(exts).toBeNull();
   });
 });
 
@@ -149,5 +150,15 @@ describe("FileViewer", () => {
 
     vi.unmock("@uiw/react-codemirror");
     vi.resetModules();
+  });
+
+  it("renders raw code when language module is missing", async () => {
+    const source = "const a = 1;";
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, text: async () => source });
+    global.fetch = fetchMock as any;
+
+    render(<FileViewer path="/repo/test.unknown" />);
+    const pre = await screen.findByTestId("raw-code");
+    expect(pre.textContent).toBe(source);
   });
 });


### PR DESCRIPTION
## Summary
- detect missing grammar modules and treat them as raw text
- show plain text viewer when CodeMirror or language loading fails
- test CodeMirror and language failure scenarios

## Testing
- `npm test`
- `cd packages/code-explorer && npx vitest run` *(fails: Objects are not valid as a React child...)*

------
https://chatgpt.com/codex/tasks/task_e_68bb37751af88331b3fe720b7e16fbad