### PR TITLE
feat(code-explorer): document tab stack state and tests

### DIFF
--- a/packages/code-explorer/src/App.test.tsx
+++ b/packages/code-explorer/src/App.test.tsx
@@ -88,8 +88,13 @@ describe("CodeExplorerApp", () => {
 
     fireEvent.click(screen.getByText("two.ts"));
     expect(await screen.findByText("/repo/two.ts")).toBeTruthy();
-
     const tabBar = screen.getByTestId("tab-bar");
+
+    // clicking already open file from tree should switch without duplicating
+    fireEvent.click(screen.getByText("one.ts"));
+    expect(await screen.findByText("/repo/one.ts")).toBeTruthy();
+    expect(within(tabBar).getAllByLabelText("Close").length).toBe(2);
+
     fireEvent.click(within(tabBar).getByText("one.ts"));
     expect(await screen.findByText("/repo/one.ts")).toBeTruthy();
 

--- a/packages/code-explorer/src/App.tsx
+++ b/packages/code-explorer/src/App.tsx
@@ -23,11 +23,14 @@ import {
 {
   "friendlyName": "Code Explorer App",
   "description": "Entry component for the Code Explorer, managing home and explorer screens.",
-  "editCount": 3,
+  "editCount": 4,
   "tags": ["ui", "app"],
   "location": "src/App",
-  "notes": "Maintains UI state for repository scanning, file viewing and tree collapse."
-
+  "notes": "Maintains UI state for repository scanning, file viewing, tab management and tree collapse.",
+  "state": {
+    "tabs": "array of open file paths in the order they were opened",
+    "active": "index of the currently selected tab"
+  }
 }
 */
 export function CodeExplorerApp() {
@@ -37,8 +40,8 @@ export function CodeExplorerApp() {
   const [showImport, setShowImport] = useState(false);
   const [repoUrl, setRepoUrl] = useState("");
   const [error, setError] = useState("");
-  const [tabs, setTabs] = useState<string[]>([]);
-  const [active, setActive] = useState(0);
+  const [tabs, setTabs] = useState<string[]>([]); // open file paths
+  const [active, setActive] = useState(0); // index of active tab
   const [filter, setFilter] = useState("");
   const [status, setStatus] = useState("");
   const [collapseKey, setCollapseKey] = useState(0);

--- a/packages/code-explorer/src/components/FileViewer.tsx
+++ b/packages/code-explorer/src/components/FileViewer.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { useToast } from "@/hooks/use-toast";
 
 interface Props {
+  /** Absolute repository path of the file to display */
   path: string;
 }
 
@@ -12,10 +13,16 @@ interface Props {
 {
   "friendlyName": "file viewer",
   "description": "Fetches and displays highlighted source code with line numbers.",
-  "editCount": 4,
+  "editCount": 5,
   "tags": ["ui", "code"],
   "location": "src/components/FileViewer",
-  "notes": "Provides copy and fullscreen controls for the current file."
+  "notes": "Provides copy and fullscreen controls for the current file.",
+  "props": { "path": "absolute repository path for the file" },
+  "state": {
+    "code": "current editor content",
+    "original": "last loaded file content",
+    "fullscreen": "whether the editor fills the screen"
+  }
 }
 */
 export async function loadLanguageFromPath(


### PR DESCRIPTION
## Summary
- document tab stack state in CodeExplorerApp
- describe FileViewer props and state
- ensure re-opening an active file switches tabs rather than duplicating

## Testing
- `npm test`
- `npx vitest run packages/code-explorer/src/App.test.tsx packages/code-explorer/src/components/FileViewer.test.tsx packages/code-explorer/__tests__/viewer-missing-module.test.tsx -c packages/code-explorer/vitest.config.ts` *(fails: Failed to resolve import "react-virtualized" and mock errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bb38dc3a148331979c6749ab340501