### PR TITLE
feat(card-builder): export OpenAPI spec

### DIFF
--- a/packages/card-builder/src/Editor.tsx
+++ b/packages/card-builder/src/Editor.tsx
@@ -13,6 +13,7 @@ import {
   arrayMove,
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
+import { generateOpenApi } from "./exportApi";
 
 // ---- Data element library -------------------------------------------------
 type DisplayMode = "display" | "input" | "edit";
@@ -383,18 +384,34 @@ export function CardEditor({ initial, onSave, onBack }: { initial?: CardConfig; 
   };
 
   const exportJson = () => {
-    const data = JSON.stringify(
-      buildConfig({ name, elements, theme, shadow, lighting, animation }),
-      null,
-      2,
-    );
-    const blob = new Blob([data], { type: "application/json" });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = "card.json";
-    a.click();
-    URL.revokeObjectURL(url);
+    const config = buildConfig({
+      name,
+      elements,
+      theme,
+      shadow,
+      lighting,
+      animation,
+    });
+
+    // Export configuration as JSON
+    const data = JSON.stringify(config, null, 2);
+    const jsonBlob = new Blob([data], { type: "application/json" });
+    const jsonUrl = URL.createObjectURL(jsonBlob);
+    const jsonLink = document.createElement("a");
+    jsonLink.href = jsonUrl;
+    jsonLink.download = "card.json";
+    jsonLink.click();
+    URL.revokeObjectURL(jsonUrl);
+
+    // Export OpenAPI spec as YAML
+    const yaml = generateOpenApi(config);
+    const yamlBlob = new Blob([yaml], { type: "application/yaml" });
+    const yamlUrl = URL.createObjectURL(yamlBlob);
+    const yamlLink = document.createElement("a");
+    yamlLink.href = yamlUrl;
+    yamlLink.download = "card.yaml";
+    yamlLink.click();
+    URL.revokeObjectURL(yamlUrl);
   };
 
   const applyCode = () => {

--- a/packages/card-builder/src/exportApi.ts
+++ b/packages/card-builder/src/exportApi.ts
@@ -1,0 +1,81 @@
+import type { CardConfig } from "./Editor";
+
+// Convert a CardConfig into an OpenAPI 3.0 YAML document
+export function generateOpenApi(config: CardConfig): string {
+  const paths: Record<string, any> = {};
+
+  for (const el of config.elements) {
+    // Button elements -> POST endpoint to handle click
+    if (el.elementId === "button") {
+      paths[`/element/${el.id}`] = {
+        post: {
+          summary: `Handle ${el.props.label || "button"} click`,
+          responses: {
+            "200": { description: "Success" },
+          },
+        },
+      };
+    }
+
+    // Input display mode -> POST endpoint to submit value
+    if (el.displayMode === "input") {
+      paths[`/element/${el.id}`] = {
+        post: {
+          summary: `Submit value for ${el.props.label || "input"}`,
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    value: { type: "string" },
+                  },
+                },
+              },
+            },
+          },
+          responses: {
+            "200": { description: "Success" },
+          },
+        },
+      };
+    }
+  }
+
+  const doc = {
+    openapi: "3.0.0",
+    info: {
+      title: config.name || "Card API",
+      version: "1.0.0",
+    },
+    paths,
+  };
+
+  return toYaml(doc);
+}
+
+// Minimal YAML serializer for our simple document structure
+function toYaml(value: any, indent = 0): string {
+  const spacing = "  ".repeat(indent);
+  if (Array.isArray(value)) {
+    return value
+      .map((v) => `${spacing}- ${toYaml(v, indent + 1).trimStart()}`)
+      .join("\n");
+  }
+  if (value && typeof value === "object") {
+    return Object.entries(value)
+      .map(([k, v]) => {
+        const child = toYaml(v, indent + 1);
+        if (typeof v === "object" && v !== null && !Array.isArray(v)) {
+          return `${spacing}${k}:\n${child}`;
+        }
+        return `${spacing}${k}: ${child.trim()}`;
+      })
+      .join("\n");
+  }
+  if (typeof value === "string") return JSON.stringify(value);
+  return String(value);
+}
+
+export default generateOpenApi;


### PR DESCRIPTION
## Summary
- add generator to convert CardConfig to OpenAPI 3.0 YAML
- export editor JSON and OpenAPI files together

## Testing
- `npm test`
- `npm run check` *(fails: Cannot find name 'siteAccessControl'; and other TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bb39975bcc8331a700e0a32b71ee64