### PR TITLE
test: warn when viewer modules missing

### DIFF
--- a/packages/code-explorer/__tests__/fixtures/missingModules.ts
+++ b/packages/code-explorer/__tests__/fixtures/missingModules.ts
@@ -1,0 +1,10 @@
+import { vi } from "vitest";
+
+// Simulate missing editor and language modules by throwing on import.
+vi.mock("@uiw/react-codemirror", () => {
+  throw new Error("Cannot find module '@uiw/react-codemirror'");
+});
+
+vi.mock("@codemirror/lang-javascript", () => {
+  throw new Error("Cannot find module '@codemirror/lang-javascript'");
+});

--- a/packages/code-explorer/__tests__/viewer-missing-module.test.tsx
+++ b/packages/code-explorer/__tests__/viewer-missing-module.test.tsx
@@ -7,33 +7,31 @@ import { describe, it, expect, vi } from "vitest";
 vi.mock("@/components/ui/button", () => ({
   Button: (props: any) => <button {...props} />,
 }));
+const toast = vi.fn();
 vi.mock("@/hooks/use-toast", () => ({
-  useToast: () => ({ toast: vi.fn() }),
+  useToast: () => ({ toast }),
 }));
 
-// Import fixture that mocks missing language module
-import "./fixtures/missingLang";
+// Import fixture that mocks missing editor and language modules
+import "./fixtures/missingModules";
 
 import { FileViewer } from "../src/components/FileViewer";
 
 describe("FileViewer missing language module", () => {
-  it("renders raw text and warns when module is missing", async () => {
+  it("renders raw text and emits a warning toast when module is missing", async () => {
     const source = "const a = 1;";
     const originalFetch = global.fetch;
     global.fetch = vi
       .fn()
       .mockResolvedValue({ ok: true, text: async () => source }) as any;
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
 
     render(<FileViewer path="/repo/test.ts" />);
 
-    const textarea = await screen.findByTestId("editor");
-    expect((textarea as HTMLTextAreaElement).value).toBe(source);
-    expect(textarea.getAttribute("extensions")).toBeNull();
+    const pre = await screen.findByTestId("raw-code");
+    expect(pre.textContent).toBe(source);
 
-    await waitFor(() => expect(warn).toHaveBeenCalled());
+    await waitFor(() => expect(toast).toHaveBeenCalled());
 
-    warn.mockRestore();
     global.fetch = originalFetch;
   });
 });

--- a/packages/code-explorer/src/components/FileViewer.tsx
+++ b/packages/code-explorer/src/components/FileViewer.tsx
@@ -91,9 +91,10 @@ export function FileViewer({ path }: Props) {
           "Failed to load CodeMirror. Rendering plain text instead.",
           err
         );
+        toast({ title: "Editor failed to load", variant: "destructive" });
         setCodeMirror(null);
       });
-  }, []);
+  }, [toast]);
 
   useEffect(() => {
     /**
@@ -125,9 +126,13 @@ export function FileViewer({ path }: Props) {
       } else {
         setLangFailed(true);
         setExtensions([]);
+        toast({
+          title: "Syntax highlighting unavailable",
+          variant: "destructive",
+        });
       }
     });
-  }, [path]);
+  }, [path, toast]);
 
   const handleSave = useCallback(async () => {
     const patch = createTwoFilesPatch(path, path, original, code);


### PR DESCRIPTION
## Summary
- add fixture to mock missing CodeMirror and language modules
- display a destructive toast when viewer modules fail to load
- test FileViewer fallback to raw text with warning toast

## Testing
- `npm test`
- `cd packages/code-explorer && npx vitest run __tests__/viewer-missing-module.test.tsx`
- `cd packages/code-explorer && npx vitest run` *(fails: Cannot find module 'react-virtualized')*


------
https://chatgpt.com/codex/tasks/task_e_68bb3a6244648331bb11f979ebd8786e