### PR TITLE
test: add card builder tests and cross-browser config

### DIFF
--- a/packages/card-builder/QA_Engineer-Codex.md
+++ b/packages/card-builder/QA_Engineer-Codex.md
@@ -1,0 +1,4 @@
+# QA Engineer – Codex
+
+## My Story So Far
+- **[2025-01-12]** Added unit tests verifying card name persistence and OpenAPI file creation. Extended cross-browser scripts to run in Chrome, Firefox, and WebKit.

--- a/packages/card-builder/src/__tests__/config.test.ts
+++ b/packages/card-builder/src/__tests__/config.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { buildConfig, parseConfig } from '../Editor';
+import generateOpenApi from '../exportApi';
+
+const base = {
+  theme: 'light',
+  shadow: 'none',
+  lighting: 'none',
+  animation: 'none',
+};
+
+describe('card builder config', () => {
+  it('preserves card name through build and parse', () => {
+    const cfg = buildConfig({ name: 'My Card', elements: [], ...base });
+    const json = JSON.stringify(cfg);
+    const parsed = parseConfig(json);
+    expect(parsed?.name).toBe('My Card');
+  });
+
+  it('generates OpenAPI YAML with card name and button path', () => {
+    const cfg = buildConfig({
+      name: 'My Card',
+      elements: [
+        {
+          id: 'btn1',
+          elementId: 'button',
+          displayMode: 'display',
+          props: { label: 'Go' },
+        },
+      ],
+      ...base,
+    });
+    const yaml = generateOpenApi(cfg);
+    expect(yaml).toContain('title: "My Card"');
+    expect(yaml).toContain('/element/btn1');
+    expect(yaml).toContain('openapi: "3.0.0"');
+  });
+});

--- a/packages/card-builder/src/__tests__/cross-browser.spec.tsx
+++ b/packages/card-builder/src/__tests__/cross-browser.spec.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import fs from 'node:fs/promises';
+import { test, expect } from '@playwright/experimental-ct-react';
+import { CardEditor } from '../Editor';
+
+test('exports OpenAPI with current card name', async ({ mount, page }) => {
+  await mount(<CardEditor onSave={() => {}} onBack={() => {}} />);
+  const nameInput = page.locator('input').first();
+  await nameInput.fill('Cross Browser Card');
+
+  const exportButton = page.getByText('Export JSON');
+  const [jsonDownload, yamlDownload] = await Promise.all([
+    page.waitForEvent('download'),
+    page.waitForEvent('download'),
+    exportButton.click(),
+  ]);
+
+  expect(jsonDownload.suggestedFilename()).toBe('card.json');
+  expect(yamlDownload.suggestedFilename()).toBe('card.yaml');
+
+  const yamlPath = await yamlDownload.path();
+  const content = await fs.readFile(yamlPath!, 'utf-8');
+  expect(content).toContain('title: "Cross Browser Card"');
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,7 +6,11 @@ import { fileURLToPath } from 'url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
-  testDir: './packages/code-explorer/e2e',
+  testDir: './',
+  testMatch: [
+    'packages/code-explorer/e2e/**/*.spec.ts',
+    'packages/card-builder/src/__tests__/**/*.spec.{ts,tsx}',
+  ],
   ctViteConfig: {
     plugins: [react()],
     resolve: {


### PR DESCRIPTION
## Summary
- add unit tests for card name persistence and OpenAPI generation
- add cross-browser Playwright spec for card builder exports
- update Playwright config to include card builder tests

## Testing
- `npx vitest run --root packages/card-builder packages/card-builder/src/__tests__/config.test.ts`
- `npm run test:playwright packages/card-builder/src/__tests__/cross-browser.spec.tsx` *(fails: browserType.launch: Executable doesn't exist and `npx playwright install` returns 403 Domain forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bb3aca59608331aa818fa1cc7974ae