### PR TITLE
test: add cross-browser save and tab tests

### DIFF
--- a/packages/code-explorer/e2e/app-tabs.spec.tsx
+++ b/packages/code-explorer/e2e/app-tabs.spec.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { test, expect } from '@playwright/experimental-ct-react';
+import { CodeExplorerApp } from '../src/App';
+
+test.describe('CodeExplorerApp tabs', () => {
+  test('opens, switches, and closes tabs without duplication', async ({ mount, page }) => {
+    const tree = {
+      name: 'repo',
+      path: '/repo',
+      children: [
+        { name: 'one.ts', path: '/repo/one.ts' },
+        { name: 'two.ts', path: '/repo/two.ts' },
+      ],
+    };
+
+    await page.route('**/code-explorer/api/clone', route =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(tree),
+      })
+    );
+    await page.route('**/code-explorer/api/file?*', route => {
+      const url = new URL(route.request().url());
+      const path = url.searchParams.get('path');
+      route.fulfill({ body: `code for ${path}` });
+    });
+    await page.route('**/code-explorer/api/save', route =>
+      route.fulfill({ status: 200, body: '{}' })
+    );
+
+    await mount(<CodeExplorerApp />);
+
+    await page.getByRole('button', { name: 'Import' }).click();
+    await page
+      .getByPlaceholder('https://github.com/user/repo')
+      .fill('https://github.com/user/repo');
+    await page.getByRole('button', { name: 'Import' }).nth(1).click();
+
+    const treePanel = page.locator('.w-64');
+    await treePanel.getByText('one.ts').click();
+    await expect(page.getByText('/repo/one.ts')).toBeVisible();
+    await treePanel.getByText('two.ts').click();
+    await expect(page.getByText('/repo/two.ts')).toBeVisible();
+
+    await treePanel.getByText('one.ts').click();
+    const tabBar = page.getByTestId('tab-bar');
+    await expect(tabBar.locator('[aria-label="Close"]')).toHaveCount(2);
+
+    await tabBar.getByText('one.ts').click();
+    await expect(page.getByText('/repo/one.ts')).toBeVisible();
+
+    await tabBar.locator('[aria-label="Close"]').nth(1).click();
+    await expect(tabBar.locator('[aria-label="Close"]')).toHaveCount(1);
+    await expect(page.getByText('/repo/one.ts')).toBeVisible();
+  });
+});

--- a/packages/code-explorer/e2e/fileviewer.spec.tsx
+++ b/packages/code-explorer/e2e/fileviewer.spec.tsx
@@ -21,6 +21,24 @@ test.describe('FileViewer', () => {
     expect(body.patch).toContain('+const a = 2;');
   });
 
+  test('saves patched content with keyboard shortcut', async ({ mount, page }) => {
+    await page.route('**/code-explorer/api/file?*', route =>
+      route.fulfill({ body: 'const a = 1;' })
+    );
+    let saveRequest;
+    await page.route('**/code-explorer/api/save', route => {
+      saveRequest = route.request();
+      route.fulfill({ status: 200, body: '{}' });
+    });
+    const component = await mount(<FileViewer path="/repo/test.ts" />);
+    const textarea = component.locator('textarea[data-testid="editor"]');
+    await textarea.fill('const a = 2;');
+    await page.keyboard.press('Control+s');
+    const body = JSON.parse(saveRequest!.postData()!);
+    expect(body.patch).toContain('-const a = 1;');
+    expect(body.patch).toContain('+const a = 2;');
+  });
+
   test('toggles fullscreen via control', async ({ mount, page }) => {
     await page.route('**/code-explorer/api/file?*', route =>
       route.fulfill({ body: 'const a = 1;' })


### PR DESCRIPTION
## Summary
- verify FileViewer saves patches via keyboard and button
- add CodeExplorerApp test covering tab open, switch, and close

## Testing
- `npm test`
- `npx playwright test` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68bb3c26e8888331813ecc3bce385980