### PR TITLE
docs: add code explorer onboarding guide

### DIFF
--- a/packages/code-explorer/README.md
+++ b/packages/code-explorer/README.md
@@ -3,6 +3,8 @@
 ## Project Purpose
 Code Explorer is a browser-based tool for navigating project source files. It scans a repository, renders a file tree, and displays files with syntax highlighting so contributors can explore code without leaving the app.
 
+New contributors should read the [Onboarding Guide](docs/onboarding.md) for setup instructions, persona workflow, testing commands, and coding conventions.
+
 ## Current Features
 - Interactive file tree for browsing directories and selecting files.
 - Syntax-highlighted viewer powered by CodeMirror with a plain-text fallback when a language mode is missing.

--- a/packages/code-explorer/docs/onboarding.md
+++ b/packages/code-explorer/docs/onboarding.md
@@ -1,0 +1,34 @@
+# Code Explorer Onboarding
+
+## Setup
+- Install dependencies:
+  ```bash
+  npm install
+  ```
+- Start the isolated explorer during development:
+  ```bash
+  npm run dev:explorer
+  ```
+- The full application can be launched with `npm run dev` if you need to view the explorer alongside the rest of the platform.
+
+## Persona Workflow
+- Team members keep a profile Markdown file in `packages/code-explorer` using the naming pattern `<Role>_<Name>-<Surname>.md`.
+- Profiles include sections for Introduction, Biography, Core Skills & Tools, Contact & Availability, Current Assignment, Current Task Notes, Project Notes, and Urgent Notes (leave empty when nothing is pressing).
+- Update your profile whenever your assignment or availability changes and at least once per sprint.
+
+## Testing Commands
+- Run all repository tests:
+  ```bash
+  npm test
+  ```
+- Run only the explorer tests:
+  ```bash
+  npx vitest run --root packages/code-explorer
+  ```
+- To focus on a single test file, pass its path to `npx vitest`.
+
+## Coding Conventions
+- The package uses TypeScript and React functional components; mirror the existing style when adding code.
+- Keep functions small and focused, and prefer descriptive names for files and symbols.
+- Maintain Markdown headings and bullet lists in documentation for clarity.
+- Run the appropriate tests before committing changes.


### PR DESCRIPTION
## Summary
- add onboarding guide for Code Explorer with setup, persona workflow, testing commands, and coding conventions
- link onboarding guide from Code Explorer README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb3f02877c833181b86f773e538893