### PR TITLE
Add OpenAPI artifacts to build and preview pipeline

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,7 @@
+[build]
+  command = "npm run build"
+  publish = "dist"
+
+[context.deploy-preview]
+  command = "npm run build"
+  publish = "dist"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "cross-env NODE_ENV=development tsx server/index.ts",
     "dev:explorer": "cross-env NODE_ENV=development tsx server/explorer.ts",
-    "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
+    "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist && tsx scripts/build-openapi.ts",
     "start": "cross-env NODE_ENV=production node dist/index.js",
     "check": "tsc",
     "test": "vitest run",

--- a/packages/card-builder/docs/devops/preview-pipeline.md
+++ b/packages/card-builder/docs/devops/preview-pipeline.md
@@ -1,0 +1,12 @@
+# Preview Pipeline
+
+This pipeline runs on every pull request to provide a live preview of card artifacts.
+
+1. **Build**
+   - `npm run build` compiles the application and triggers `scripts/build-openapi.ts`.
+   - The script writes `card.json` and `card.yaml` to the `dist/` directory.
+2. **Deploy Preview**
+   - Netlify uses `netlify.toml` to build and publish the `dist/` folder for PRs.
+   - The preview URL exposes the generated artifacts at `/card.json` and `/card.yaml`.
+
+These steps ensure every pull request has a preview environment serving both the card configuration and its corresponding OpenAPI specification.

--- a/scripts/build-openapi.ts
+++ b/scripts/build-openapi.ts
@@ -1,0 +1,20 @@
+import { mkdirSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { generateOpenApi } from '../packages/card-builder/src/exportApi';
+import type { CardConfig } from '../packages/card-builder/src/Editor';
+
+const config: CardConfig = {
+  name: 'Preview Card',
+  elements: [],
+  theme: 'light',
+  shadow: 'none',
+  lighting: 'none',
+  animation: 'none',
+};
+
+const yaml = generateOpenApi(config);
+const dist = join(process.cwd(), 'dist');
+mkdirSync(dist, { recursive: true });
+writeFileSync(join(dist, 'card.yaml'), yaml);
+writeFileSync(join(dist, 'card.json'), JSON.stringify(config, null, 2));
+console.log('Wrote OpenAPI spec and card JSON to dist/');


### PR DESCRIPTION
## Summary
- generate OpenAPI spec and card JSON during build
- configure Netlify preview builds to publish card artifacts
- document preview pipeline for card builder

## Testing
- `npm test`
- `npm run build` *(fails: Rollup failed to resolve import "@codemirror/lang-json" from packages/code-explorer/src/components/FileViewer.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68bb3f2d41a48331954ded444a090214