### PR TITLE
test(card-builder): add unit and cross-browser export tests

### DIFF
--- a/packages/card-builder/src/__tests__/config.test.ts
+++ b/packages/card-builder/src/__tests__/config.test.ts
@@ -1,3 +1,6 @@
+// Unit tests for the card builder's configuration utilities. These ensure that
+// a card's name survives a round trip through `buildConfig`/`parseConfig` and
+// that the OpenAPI export contains expected metadata.
 import { describe, it, expect } from 'vitest';
 import { buildConfig, parseConfig } from '../Editor';
 import generateOpenApi from '../exportApi';

--- a/packages/card-builder/src/__tests__/cross-browser.spec.tsx
+++ b/packages/card-builder/src/__tests__/cross-browser.spec.tsx
@@ -3,10 +3,13 @@ import fs from 'node:fs/promises';
 import { test, expect } from '@playwright/experimental-ct-react';
 import { CardEditor } from '../Editor';
 
-test('exports OpenAPI with current card name', async ({ mount, page }) => {
+// Run this component test in all configured browsers to ensure that editing the
+// card and exporting assets behaves the same everywhere. The Playwright config
+// already defines Chromium, Firefox and WebKit projects so this single test
+// will execute in each browser.
+test('exports assets with current card name', async ({ mount, page }) => {
   await mount(<CardEditor onSave={() => {}} onBack={() => {}} />);
-  const nameInput = page.locator('input').first();
-  await nameInput.fill('Cross Browser Card');
+  await page.locator('input').first().fill('Cross Browser Card');
 
   const exportButton = page.getByText('Export JSON');
   const [jsonDownload, yamlDownload] = await Promise.all([
@@ -18,7 +21,12 @@ test('exports OpenAPI with current card name', async ({ mount, page }) => {
   expect(jsonDownload.suggestedFilename()).toBe('card.json');
   expect(yamlDownload.suggestedFilename()).toBe('card.yaml');
 
+  const jsonPath = await jsonDownload.path();
   const yamlPath = await yamlDownload.path();
-  const content = await fs.readFile(yamlPath!, 'utf-8');
-  expect(content).toContain('title: "Cross Browser Card"');
+  const jsonContent = await fs.readFile(jsonPath!, 'utf-8');
+  const yamlContent = await fs.readFile(yamlPath!, 'utf-8');
+
+  expect(jsonContent).toContain('"name": "Cross Browser Card"');
+  expect(yamlContent).toContain('title: "Cross Browser Card"');
+  expect(yamlContent).toContain('openapi: "3.0.0"');
 });


### PR DESCRIPTION
## Summary
- document configuration unit tests ensuring card names persist and OpenAPI exports include expected metadata
- expand Playwright test to verify JSON and YAML downloads across Chromium, Firefox, and WebKit

## Testing
- `npm test`
- `npx vitest run --root . packages/card-builder/src/__tests__/config.test.ts`
- `npm run test:playwright` *(fails: browser binaries blocked by 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bb4377127c8331babf0f80170a118f