### PR TITLE
feat(code-explorer): add editor fallback

### DIFF
--- a/packages/code-explorer/Frontend_Developer-Simon_Hesher.md
+++ b/packages/code-explorer/Frontend_Developer-Simon_Hesher.md
@@ -32,6 +32,8 @@ drag-and-drop libraries, and dependency graph automation.
   delays.
 - Expand regression testing guidance for large directory scans with nested
   symlinks and files without extensions.
+- Implemented a plain-text fallback in FileViewer when CodeMirror or a grammar
+  fails to load; updated component state docs and tests.
 
 ## 🔮 Future Designs
 - Cross-fade transitions when switching between the Function Browser, Canvas, and Code Pane.


### PR DESCRIPTION
## Summary
- add error boundary to FileViewer to fall back to raw text when CodeMirror or language grammar fails
- document component state and update persona notes
- test fallback behavior including runtime CodeMirror crash

## Testing
- `npm test`
- `npx vitest run packages/code-explorer/src/components/FileViewer.test.tsx --config packages/code-explorer/vitest.config.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bb43d1eeb88331b3b89de9134278d0