### PR TITLE
docs: add card export and style guidelines

### DIFF
--- a/packages/card-builder/docs/exporting-cards.md
+++ b/packages/card-builder/docs/exporting-cards.md
@@ -1,0 +1,10 @@
+# Exporting Cards
+
+The Card Builder lets you export a designed card along with its API description. Use the **Export** button in the toolbar to download:
+
+- **Card JSON** – a snapshot of the card's layout and settings.
+- **OpenAPI spec** – a machine‑readable description of the endpoints generated for the card.
+
+Choose your desired format from the export dropdown. The browser will download the selected files, which you can integrate into your application or share with others.
+
+> _Implementation details are verified with Backend Developer Tariq Al‑Fulani and Frontend Developer Casey Rivera so the export flow remains consistent with the codebase._

--- a/packages/card-builder/docs/style-guide.md
+++ b/packages/card-builder/docs/style-guide.md
@@ -1,0 +1,18 @@
+# Documentation Style Guide
+
+## Tone
+- Write in a friendly, conversational voice.
+- Prefer active verbs and clear stage directions.
+- Keep paragraphs short and inviting.
+
+## Naming Conventions
+- Refer to the product as **Card Builder**.
+- Use `camelCase` for function names and `PascalCase` for components.
+- File names are `kebab-case.md`.
+
+## Code Blocks
+- Annotate code fences with the language: ```` ```ts```` or ```` ```json````.
+- Keep examples focused and no wider than 80 characters.
+- Show input and output when it aids understanding.
+
+> Sync with engineering personas—Backend Developer Tariq Al-Fulani and Frontend Developer Casey Rivera—before publishing major changes to ensure docs match the implementation.


### PR DESCRIPTION
## Summary
- document how to download card JSON and OpenAPI specs
- add documentation style guide with tone, naming, and code block rules

## Testing
- `npm test`
- `npm run pre-commit`


------
https://chatgpt.com/codex/tasks/task_e_68bb44f9d214833180f964d4385d406b