### PR TITLE
test: cover file viewer fallbacks and patch edge cases

### DIFF
--- a/packages/code-explorer/QA_Engineer-Maria_Li.md
+++ b/packages/code-explorer/QA_Engineer-Maria_Li.md
@@ -22,9 +22,9 @@ Maria brings a detail-oriented mindset shaped by years of testing complex web ap
 Prioritizing regression tests for large directory scans with nested symlinks and files without extensions.
 
 ## 📝 Current Task Notes
-- Preparing test fixtures for nested symlink directories and extensionless files.
-- Added fixtures to emulate missing syntax modules and verify FileViewer warnings.
-- Attempted to validate save/patch flow and fullscreen viewer controls across Chromium, Firefox, and WebKit using Playwright, but browser binaries failed to install (HTTP 403).
+- Added regression tests covering nested symlink directories and extensionless files in the save/patch flow.
+- Verified FileViewer falls back to raw text and emits warning toasts when syntax modules are missing or the editor crashes.
+- Prior Playwright validation was blocked; browser binaries failed to install (HTTP 403).
 
 ## 🗂️ Project Notes
 - Completed review of recent bug reports to design targeted tests.

--- a/packages/code-explorer/__tests__/save.test.ts
+++ b/packages/code-explorer/__tests__/save.test.ts
@@ -15,4 +15,28 @@ describe("applyPatchToFile", () => {
     const result = await fs.readFile(file, "utf8");
     expect(result).toBe("const a = 2;\n");
   });
+
+  it("patches files without extensions", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "patch-extless"));
+    const file = path.join(dir, "README");
+    await fs.writeFile(file, "hello\n");
+    const patch = createTwoFilesPatch("README", "README", "hello\n", "world\n");
+    await applyPatchToFile(file, patch);
+    const result = await fs.readFile(file, "utf8");
+    expect(result).toBe("world\n");
+  });
+
+  it("follows nested symlinks when patching", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "patch-symlink"));
+    const target = path.join(dir, "target.txt");
+    await fs.writeFile(target, "one\n");
+    const link1 = path.join(dir, "link1");
+    const link2 = path.join(dir, "link2");
+    await fs.symlink(target, link1);
+    await fs.symlink(link1, link2);
+    const patch = createTwoFilesPatch("link2", "link2", "one\n", "two\n");
+    await applyPatchToFile(link2, patch);
+    const result = await fs.readFile(target, "utf8");
+    expect(result).toBe("two\n");
+  });
 });

--- a/packages/code-explorer/__tests__/viewer-fallback.test.tsx
+++ b/packages/code-explorer/__tests__/viewer-fallback.test.tsx
@@ -1,0 +1,87 @@
+/* @vitest-environment jsdom */
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+
+const toast = vi.fn();
+
+describe("FileViewer fallback", () => {
+  it("renders raw text and warns for extensionless files", async () => {
+    vi.resetModules();
+    toast.mockReset();
+    document.body.innerHTML = "";
+    vi.doMock("@/components/ui/button", () => ({
+      Button: (props: any) => <button {...props} />,
+    }));
+    vi.doMock("@/hooks/use-toast", () => ({
+      useToast: () => ({ toast }),
+    }));
+    vi.doMock("@uiw/react-codemirror", () => ({
+      default: (props: any) => <textarea {...props} />,
+    }));
+
+    const source = "hello";
+    const originalFetch = global.fetch;
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue({ ok: true, text: async () => source }) as any;
+
+    const { FileViewer } = await import("../src/components/FileViewer");
+
+    render(<FileViewer path="/repo/README" />);
+
+    await screen.findByText(source);
+    const pre = screen.getByTestId("raw-code");
+    expect(pre.textContent).toBe(source);
+
+    await waitFor(() =>
+      expect(toast).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "Syntax highlighting unavailable" })
+      )
+    );
+
+    global.fetch = originalFetch;
+  });
+
+  it("renders raw text and warns when CodeMirror crashes", async () => {
+    vi.resetModules();
+    toast.mockReset();
+    document.body.innerHTML = "";
+    vi.doMock("@/components/ui/button", () => ({
+      Button: (props: any) => <button {...props} />,
+    }));
+    vi.doMock("@/hooks/use-toast", () => ({
+      useToast: () => ({ toast }),
+    }));
+    vi.doMock("@uiw/react-codemirror", () => ({
+      default: () => {
+        throw new Error("boom");
+      },
+    }));
+    vi.doMock("@codemirror/lang-javascript", () => ({
+      javascript: () => ({}),
+    }));
+
+    const source = "const a = 1;";
+    const originalFetch = global.fetch;
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue({ ok: true, text: async () => source }) as any;
+
+    const { FileViewer } = await import("../src/components/FileViewer");
+
+    render(<FileViewer path="/repo/test.ts" />);
+
+    await screen.findByText(source);
+    const pre = screen.getByTestId("raw-code");
+    expect(pre.textContent).toBe(source);
+
+    await waitFor(() =>
+      expect(toast).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "Editor failed to load" })
+      )
+    );
+
+    global.fetch = originalFetch;
+  });
+});


### PR DESCRIPTION
## Summary
- extend save/patch flow tests to handle extensionless files and nested symlinks
- add FileViewer fallback tests for extensionless files and CodeMirror crash scenarios
- document regression results in QA_Engineer-Maria_Li profile

## Testing
- `npx vitest run --config packages/code-explorer/vitest.config.ts packages/code-explorer/__tests__/save.test.ts packages/code-explorer/__tests__/viewer-fallback.test.tsx packages/code-explorer/__tests__/viewer-missing-module.test.tsx packages/code-explorer/__tests__/file-tree.test.ts`
- `npm run pre-commit`

------
https://chatgpt.com/codex/tasks/task_e_68bb45338ee883318237c7f84fc011ad