### PR TITLE
docs: add Code Explorer runbook and release-note plan

### DIFF
--- a/packages/code-explorer/Documentation_Ops-Alex_Kim.md
+++ b/packages/code-explorer/Documentation_Ops-Alex_Kim.md
@@ -21,7 +21,8 @@ Alex blends technical writing with operations experience, ensuring documentation
 Standardize repository documentation and automate release notes.
 
 ## 📝 Current Task Notes
-- Drafting runbooks for code explorer deployment.
+- Published Code Explorer runbook covering tests, save/patch flow, and viewer fallback.
+- Tracking automated release-note tooling; next step is wiring changelog script into CI.
 
 ## 🗂️ Project Notes
 - Reference documentation kept in `/docs`; update as features stabilize.

--- a/packages/code-explorer/docs/runbook.md
+++ b/packages/code-explorer/docs/runbook.md
@@ -1,0 +1,33 @@
+# Code Explorer Runbook
+
+## Test Setup
+- Install dependencies:
+  ```bash
+  npm install
+  ```
+- Run the full test suite:
+  ```bash
+  npm test
+  ```
+- Run only explorer tests with Vitest:
+  ```bash
+  npx vitest run --root packages/code-explorer
+  ```
+- Focus on a single spec by passing its path to `npx vitest`.
+
+## Save & Patch Workflow
+- The FileViewer editor generates a unified diff using `createTwoFilesPatch` when a file is saved.
+- The client posts `{ path, patch }` to `/code-explorer/api/save`.
+- The server's `applyPatchToFile` utility applies the diff with `Diff.applyPatch` and writes the result back to disk.
+- If patching fails, the server responds with an error and the file remains unchanged.
+
+## Viewer Fallback Behavior
+- Code highlighting uses Prism grammars.
+- When a language definition is missing or Prism throws, `highlightCode` returns the original string so the viewer renders plain text instead of crashing.
+
+## Release Notes Automation
+- Changelog generation script: `node packages/code-explorer/scripts/generate-changelog.js CHANGELOG.md`.
+- Next steps:
+  - Wire the script into CI to run on tagged releases.
+  - Enforce conventional commit messages to improve grouping.
+  - Publish generated notes to the repository's releases page.


### PR DESCRIPTION
## Summary
- add Code Explorer runbook detailing test commands, save/patch workflow, viewer fallback, and release-note automation plan
- log runbook publication and release-note tooling progress in Alex Kim's persona

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb4719e69083318d7bded17a140cf6