### PR TITLE
Refactor card builder editor into modular components

### DIFF
--- a/packages/card-builder/src/Editor.tsx
+++ b/packages/card-builder/src/Editor.tsx
@@ -1,312 +1,47 @@
 import React, { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
+import { DndContext } from "@dnd-kit/core";
+import { Palette } from "./palette";
+import { CardCanvas } from "./canvas";
+import { PropertiesPanel } from "./properties-panel";
+import { elementLibrary } from "./elements";
+import { useDragAndDrop } from "./hooks/useDragAndDrop";
 import {
-  DndContext,
-  useDraggable,
-  useDroppable,
-  DragEndEvent,
-} from "@dnd-kit/core";
-import {
-  SortableContext,
-  verticalListSortingStrategy,
-  useSortable,
-  arrayMove,
-} from "@dnd-kit/sortable";
-import { CSS } from "@dnd-kit/utilities";
-import { generateOpenApi } from "./exportApi";
+  buildConfig,
+  parseConfig,
+  exportAssets,
+  CardConfig,
+} from "./export-helpers";
 
-// ---- Data element library -------------------------------------------------
-type DisplayMode = "display" | "input" | "edit";
+export { buildConfig, parseConfig, type CardConfig } from "./export-helpers";
 
-export type ElementDefinition = {
-  id: string;
-  label: string;
-  type: "text" | "number" | "image" | "button";
-  displayModes: DisplayMode[];
-  defaultProps: Record<string, any>;
-  validation?: Record<string, any>;
-};
-
-export const elementLibrary: ElementDefinition[] = [
-  {
-    id: "title",
-    label: "Title",
-    type: "text",
-    displayModes: ["display"],
-    defaultProps: { label: "Sample Title" },
-    validation: { required: true },
-  },
-  {
-    id: "description",
-    label: "Description",
-    type: "text",
-    displayModes: ["display"],
-    defaultProps: { label: "Sample description" },
-  },
-  {
-    id: "image",
-    label: "Image",
-    type: "image",
-    displayModes: ["display"],
-    defaultProps: {
-      src: "https://via.placeholder.com/300x100?text=Image",
-      alt: "sample image",
-    },
-  },
-  {
-    id: "input",
-    label: "Input Field",
-    type: "text",
-    displayModes: ["input"],
-    defaultProps: { label: "Field", placeholder: "Enter text" },
-    validation: { required: false },
-  },
-  {
-    id: "button",
-    label: "Button",
-    type: "button",
-    displayModes: ["display"],
-    defaultProps: { label: "Click" },
-  },
-];
-
-// ---- Palette item ---------------------------------------------------------
-function PaletteItem({ def }: { def: ElementDefinition }) {
-  const { attributes, listeners, setNodeRef, transform } = useDraggable({
-    id: def.id,
-    data: { from: "palette" },
-  });
-  const style = {
-    transform: CSS.Translate.toString(transform),
-  };
-  return (
-    <div
-      ref={setNodeRef}
-      {...listeners}
-      {...attributes}
-      style={style}
-      className="border p-2 mb-2 cursor-move bg-gray-200 text-sm"
-    >
-      {def.label}
-    </div>
-  );
-}
-
-// ---- Card canvas ----------------------------------------------------------
-export function CardCanvas({
-  theme,
-  shadow,
-  lighting,
-  animation,
-  children,
+export function CardEditor({
+  initial,
+  onSave,
+  onBack,
 }: {
-  theme: string;
-  shadow: string;
-  lighting: string;
-  animation: string;
-  children: React.ReactNode;
+  initial?: CardConfig;
+  onSave: (config: CardConfig) => void;
+  onBack: () => void;
 }) {
-  const { setNodeRef } = useDroppable({ id: "card" });
-  const themeClass =
-    theme === "dark"
-      ? "bg-gray-900 text-white"
-      : theme === "neon"
-      ? "bg-gradient-to-r from-blue-500 to-pink-500 text-white"
-      : "bg-white text-black";
-  const shadowClass =
-    shadow === "soft" ? "shadow-md" : shadow === "strong" ? "shadow-xl" : "";
-  const lightingClass =
-    lighting === "glow"
-      ? "ring-2 ring-blue-400"
-      : lighting === "neon"
-      ? "ring-2 ring-pink-500"
-      : "";
-  const animationClass =
-    animation === "fade"
-      ? "animate-in fade-in"
-      : animation === "hover"
-      ? "transition-transform hover:scale-105"
-      : "";
-  return (
-    <div
-      ref={setNodeRef}
-      className={`w-96 min-h-[15rem] border p-4 flex flex-col gap-2 ${themeClass} ${shadowClass} ${lightingClass} ${animationClass}`}
-    >
-      {children}
-    </div>
-  );
-}
-
-// ---- Card item ------------------------------------------------------------
-export type ElementInstance = {
-  id: string;
-  elementId: string;
-  displayMode: DisplayMode;
-  props: Record<string, any>;
-};
-
-function CardItem({
-  item,
-  onRemove,
-  onSelect,
-  selected,
-}: {
-  item: ElementInstance;
-  onRemove: (id: string) => void;
-  onSelect: (id: string) => void;
-  selected: boolean;
-}) {
-  const { attributes, listeners, setNodeRef, transform, transition } =
-    useSortable({ id: item.id, data: { from: "card" } });
-  const style = {
-    transform: CSS.Transform.toString(transform),
-    transition,
-  };
-  const def = elementLibrary.find((d) => d.id === item.elementId)!;
-  return (
-    <div
-      ref={setNodeRef}
-      style={style}
-      {...attributes}
-      {...listeners}
-      onClick={() => onSelect(item.id)}
-      className={`relative border p-2 bg-white text-black cursor-move ${
-        selected ? "ring-2 ring-blue-400" : ""
-      }`}
-    >
-      <button
-        onClick={() => onRemove(item.id)}
-        className="absolute -top-2 -right-2 bg-red-500 text-white rounded-full w-5 h-5 text-xs"
-      >
-        ×
-      </button>
-      {def.type === "text" && item.displayMode !== "input" && (
-        <div>{item.props.label || def.defaultProps.label}</div>
-      )}
-      {def.type === "text" && item.displayMode === "input" && (
-        <div>
-          <label className="block mb-1">
-            {item.props.label || def.defaultProps.label}
-          </label>
-          <input
-            className="border px-1"
-            placeholder={
-              item.props.placeholder || def.defaultProps.placeholder
-            }
-          />
-        </div>
-      )}
-      {def.type === "number" && (
-        <div>{item.props.value ?? 0}</div>
-      )}
-      {def.type === "image" && (
-        <img
-          src={item.props.src || def.defaultProps.src}
-          alt={item.props.alt || def.defaultProps.alt}
-          className="w-full h-24 object-cover"
-        />
-      )}
-      {def.type === "button" && (
-        <button className="px-2 py-1 border">
-          {item.props.label || def.defaultProps.label}
-        </button>
-      )}
-    </div>
-  );
-}
-
-// ---- Code serialization helpers -----------------------------------------
-export function buildConfig({
-  name,
-  elements,
-  theme,
-  shadow,
-  lighting,
-  animation,
-}: {
-  name: string;
-  elements: ElementInstance[];
-  theme: string;
-  shadow: string;
-  lighting: string;
-  animation: string;
-}) {
-  return {
-    name,
-    theme,
-    shadow,
-    lighting,
-    animation,
-    elements: elements.map((el) => ({
-      id: el.id,
-      elementId: el.elementId,
-      displayMode: el.displayMode,
-      props: el.props,
-    })),
-  };
-}
-
-export function parseConfig(json: string): {
-  name: string;
-  elements: ElementInstance[];
-  theme: string;
-  shadow: string;
-  lighting: string;
-  animation: string;
-} | null {
-  try {
-    const obj = JSON.parse(json);
-    if (!obj || typeof obj !== "object") return null;
-    const elements: ElementInstance[] = Array.isArray(obj.elements)
-      ? obj.elements
-          .map((el: any) => {
-            const def = elementLibrary.find((d) => d.id === el.elementId);
-            if (!def) return null;
-            const mode: DisplayMode = def.displayModes.includes(el.displayMode)
-              ? el.displayMode
-              : def.displayModes[0];
-            return {
-              id: el.id || Date.now().toString(),
-              elementId: def.id,
-              displayMode: mode,
-              props: el.props || {},
-            };
-          })
-          .filter(Boolean)
-      : [];
-    return {
-      name: typeof obj.name === "string" ? obj.name : "Untitled Card",
-      elements,
-      theme: obj.theme || "light",
-      shadow: obj.shadow || "none",
-      lighting: obj.lighting || "none",
-      animation: obj.animation || "none",
-    };
-  } catch (e) {
-    return null;
-  }
-}
-
-// ---- Main app ------------------------------------------------------------
-export interface CardConfig {
-  name: string;
-  elements: ElementInstance[];
-  theme: string;
-  shadow: string;
-  lighting: string;
-  animation: string;
-}
-
-export function CardEditor({ initial, onSave, onBack }: { initial?: CardConfig; onSave: (config: CardConfig) => void; onBack: () => void; }) {
   const [name, setName] = useState("Untitled Card");
-  const [elements, setElements] = useState<ElementInstance[]>([]);
   const [theme, setTheme] = useState("light");
   const [shadow, setShadow] = useState("none");
   const [lighting, setLighting] = useState("none");
   const [animation, setAnimation] = useState("none");
-  const [selectedId, setSelectedId] = useState<string | null>(null);
   const [showCode, setShowCode] = useState(false);
   const [code, setCode] = useState("{}");
+
+  const {
+    elements,
+    setElements,
+    selected,
+    selectedId,
+    setSelectedId,
+    handleDragEnd,
+    removeElement,
+    updateSelected,
+  } = useDragAndDrop();
 
   useEffect(() => {
     if (initial) {
@@ -317,7 +52,7 @@ export function CardEditor({ initial, onSave, onBack }: { initial?: CardConfig; 
       setLighting(initial.lighting);
       setAnimation(initial.animation);
     }
-  }, [initial]);
+  }, [initial, setElements]);
 
   useEffect(() => {
     setCode(
@@ -328,91 +63,6 @@ export function CardEditor({ initial, onSave, onBack }: { initial?: CardConfig; 
       ),
     );
   }, [name, elements, theme, shadow, lighting, animation]);
-
-  const handleDragEnd = (event: DragEndEvent) => {
-    const { over, active } = event;
-    if (!over) return;
-
-    // dropping from palette onto card
-    if (active.data.current?.from === "palette" && over.id === "card") {
-      const def = elementLibrary.find((d) => d.id === active.id);
-      if (!def) return;
-      let mode: DisplayMode = def.displayModes[0];
-      if (def.displayModes.length > 1) {
-        const input = window.prompt(
-          `Display mode (${def.displayModes.join(",")}):`,
-          def.displayModes[0],
-        );
-        if (input && def.displayModes.includes(input as DisplayMode)) {
-          mode = input as DisplayMode;
-        }
-      }
-      const instance: ElementInstance = {
-        id: Date.now().toString(),
-        elementId: def.id,
-        displayMode: mode,
-        props: { ...def.defaultProps },
-      };
-      setElements((els) => [...els, instance]);
-      return;
-    }
-
-    // reorder within card
-    if (active.data.current?.from === "card" && over.id !== "card") {
-      const oldIndex = elements.findIndex((el) => el.id === active.id);
-      const newIndex = elements.findIndex((el) => el.id === over.id);
-      if (oldIndex !== -1 && newIndex !== -1 && oldIndex !== newIndex) {
-        setElements((els) => arrayMove(els, oldIndex, newIndex));
-      }
-    }
-  };
-
-  const removeElement = (id: string) => {
-    setElements((els) => els.filter((el) => el.id !== id));
-    if (selectedId === id) setSelectedId(null);
-  };
-
-  const selected = elements.find((el) => el.id === selectedId) || null;
-
-  const updateSelected = (props: Record<string, any>) => {
-    if (!selected) return;
-    setElements((els) =>
-      els.map((el) =>
-        el.id === selected.id ? { ...el, props: { ...el.props, ...props } } : el,
-      ),
-    );
-  };
-
-  const exportAssets = () => {
-    const config = buildConfig({
-      name,
-      elements,
-      theme,
-      shadow,
-      lighting,
-      animation,
-    });
-
-    // Export configuration as JSON
-    const data = JSON.stringify(config, null, 2);
-    const jsonBlob = new Blob([data], { type: "application/json" });
-    const jsonUrl = URL.createObjectURL(jsonBlob);
-    const jsonLink = document.createElement("a");
-    jsonLink.href = jsonUrl;
-    jsonLink.download = "card.json";
-    jsonLink.click();
-    URL.revokeObjectURL(jsonUrl);
-
-    // Export OpenAPI spec as YAML
-    const yaml = generateOpenApi(config);
-    const yamlBlob = new Blob([yaml], { type: "application/yaml" });
-    const yamlUrl = URL.createObjectURL(yamlBlob);
-    const yamlLink = document.createElement("a");
-    yamlLink.href = yamlUrl;
-    yamlLink.download = "card.yaml";
-    yamlLink.click();
-    URL.revokeObjectURL(yamlUrl);
-  };
 
   const applyCode = () => {
     const parsed = parseConfig(code);
@@ -486,7 +136,14 @@ export function CardEditor({ initial, onSave, onBack }: { initial?: CardConfig; 
         <Button
           onClick={() =>
             onSave(
-              buildConfig({ name, elements, theme, shadow, lighting, animation }),
+              buildConfig({
+                name,
+                elements,
+                theme,
+                shadow,
+                lighting,
+                animation,
+              }),
             )
           }
         >
@@ -495,7 +152,21 @@ export function CardEditor({ initial, onSave, onBack }: { initial?: CardConfig; 
         <Button onClick={() => setShowCode((v) => !v)} className="ml-auto">
           {showCode ? "Design View" : "Code View"}
         </Button>
-        <Button onClick={exportAssets} variant="secondary">
+        <Button
+          onClick={() =>
+            exportAssets(
+              buildConfig({
+                name,
+                elements,
+                theme,
+                shadow,
+                lighting,
+                animation,
+              }),
+            )
+          }
+          variant="secondary"
+        >
           Export Assets
         </Button>
       </div>
@@ -508,81 +179,33 @@ export function CardEditor({ initial, onSave, onBack }: { initial?: CardConfig; 
             className="border p-2 font-mono h-80"
           />
           <div>
-            <Button onClick={applyCode} className="mr-2">Apply</Button>
-            <Button onClick={() => setShowCode(false)} variant="outline">Cancel</Button>
+            <Button onClick={applyCode} className="mr-2">
+              Apply
+            </Button>
+            <Button onClick={() => setShowCode(false)} variant="outline">
+              Cancel
+            </Button>
           </div>
         </div>
       ) : (
         <DndContext onDragEnd={handleDragEnd}>
           <div className="flex gap-4">
-            <div>
-              {elementLibrary.map((def) => (
-                <PaletteItem key={def.id} def={def} />
-              ))}
-            </div>
+            <Palette elements={elementLibrary} />
             <CardCanvas
               theme={theme}
               shadow={shadow}
               lighting={lighting}
               animation={animation}
-            >
-              <SortableContext
-                items={elements.map((e) => e.id)}
-                strategy={verticalListSortingStrategy}
-              >
-                {elements.map((el) => (
-                  <CardItem
-                    key={el.id}
-                    item={el}
-                    onRemove={removeElement}
-                    onSelect={(id) => setSelectedId(id)}
-                    selected={selectedId === el.id}
-                  />
-                ))}
-              </SortableContext>
-            </CardCanvas>
+              elements={elements}
+              onRemove={removeElement}
+              onSelect={setSelectedId}
+              selectedId={selectedId}
+            />
           </div>
         </DndContext>
       )}
 
-      {selected && (
-        <div className="border p-2 w-96">
-          <div className="mb-2 font-bold">Element Properties</div>
-          <div className="flex flex-col gap-2">
-            <label className="flex gap-2 items-center">
-              <span className="w-24">Label</span>
-              <input
-                className="border px-2 py-1 flex-1"
-                value={selected.props.label || ""}
-                onChange={(e) => updateSelected({ label: e.target.value })}
-              />
-            </label>
-            {selected.displayMode === "input" && (
-              <label className="flex gap-2 items-center">
-                <span className="w-24">Placeholder</span>
-                <input
-                  className="border px-2 py-1 flex-1"
-                  value={selected.props.placeholder || ""}
-                  onChange={(e) =>
-                    updateSelected({ placeholder: e.target.value })
-                  }
-                />
-              </label>
-            )}
-            {selected.elementId === "image" && (
-              <label className="flex gap-2 items-center">
-                <span className="w-24">Image URL</span>
-                <input
-                  className="border px-2 py-1 flex-1"
-                  value={selected.props.src || ""}
-                  onChange={(e) => updateSelected({ src: e.target.value })}
-                />
-              </label>
-            )}
-          </div>
-        </div>
-      )}
+      <PropertiesPanel selected={selected} updateSelected={updateSelected} />
     </div>
   );
 }
-

--- a/packages/card-builder/src/canvas.tsx
+++ b/packages/card-builder/src/canvas.tsx
@@ -1,0 +1,137 @@
+import React from "react";
+import { useDroppable } from "@dnd-kit/core";
+import {
+  SortableContext,
+  verticalListSortingStrategy,
+  useSortable,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { ElementInstance, elementLibrary } from "./elements";
+
+function CardItem({
+  item,
+  onRemove,
+  onSelect,
+  selected,
+}: {
+  item: ElementInstance;
+  onRemove: (id: string) => void;
+  onSelect: (id: string) => void;
+  selected: boolean;
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition } =
+    useSortable({ id: item.id, data: { from: "card" } });
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+  const def = elementLibrary.find((d) => d.id === item.elementId)!;
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      {...attributes}
+      {...listeners}
+      onClick={() => onSelect(item.id)}
+      className={`relative border p-2 bg-white text-black cursor-move ${
+        selected ? "ring-2 ring-blue-400" : ""
+      }`}
+    >
+      <button
+        onClick={() => onRemove(item.id)}
+        className="absolute -top-2 -right-2 bg-red-500 text-white rounded-full w-5 h-5 text-xs"
+      >
+        ×
+      </button>
+      {def.type === "text" && item.displayMode !== "input" && (
+        <div>{item.props.label || def.defaultProps.label}</div>
+      )}
+      {def.type === "text" && item.displayMode === "input" && (
+        <div>
+          <label className="block mb-1">
+            {item.props.label || def.defaultProps.label}
+          </label>
+          <input
+            className="border px-1"
+            placeholder={item.props.placeholder || def.defaultProps.placeholder}
+          />
+        </div>
+      )}
+      {def.type === "number" && (
+        <div>{item.props.value ?? 0}</div>
+      )}
+      {def.type === "image" && (
+        <img
+          src={item.props.src || def.defaultProps.src}
+          alt={item.props.alt || def.defaultProps.alt}
+          className="w-full h-24 object-cover"
+        />
+      )}
+      {def.type === "button" && (
+        <button className="px-2 py-1 border">
+          {item.props.label || def.defaultProps.label}
+        </button>
+      )}
+    </div>
+  );
+}
+
+export function CardCanvas({
+  theme,
+  shadow,
+  lighting,
+  animation,
+  elements,
+  onRemove,
+  onSelect,
+  selectedId,
+}: {
+  theme: string;
+  shadow: string;
+  lighting: string;
+  animation: string;
+  elements: ElementInstance[];
+  onRemove: (id: string) => void;
+  onSelect: (id: string) => void;
+  selectedId: string | null;
+}) {
+  const { setNodeRef } = useDroppable({ id: "card" });
+  const themeClass =
+    theme === "dark"
+      ? "bg-gray-900 text-white"
+      : theme === "neon"
+      ? "bg-gradient-to-r from-blue-500 to-pink-500 text-white"
+      : "bg-white text-black";
+  const shadowClass =
+    shadow === "soft" ? "shadow-md" : shadow === "strong" ? "shadow-xl" : "";
+  const lightingClass =
+    lighting === "glow"
+      ? "ring-2 ring-blue-400"
+      : lighting === "neon"
+      ? "ring-2 ring-pink-500"
+      : "";
+  const animationClass =
+    animation === "fade"
+      ? "animate-in fade-in"
+      : animation === "hover"
+      ? "transition-transform hover:scale-105"
+      : "";
+  return (
+    <div
+      ref={setNodeRef}
+      className={`w-96 min-h-[15rem] border p-4 flex flex-col gap-2 ${themeClass} ${shadowClass} ${lightingClass} ${animationClass}`}
+    >
+      <SortableContext items={elements.map((e) => e.id)} strategy={verticalListSortingStrategy}>
+        {elements.map((el) => (
+          <CardItem
+            key={el.id}
+            item={el}
+            onRemove={onRemove}
+            onSelect={onSelect}
+            selected={selectedId === el.id}
+          />
+        ))}
+      </SortableContext>
+    </div>
+  );
+}

--- a/packages/card-builder/src/elements/index.ts
+++ b/packages/card-builder/src/elements/index.ts
@@ -1,0 +1,60 @@
+export type DisplayMode = "display" | "input" | "edit";
+
+export type ElementDefinition = {
+  id: string;
+  label: string;
+  type: "text" | "number" | "image" | "button";
+  displayModes: DisplayMode[];
+  defaultProps: Record<string, any>;
+  validation?: Record<string, any>;
+};
+
+export type ElementInstance = {
+  id: string;
+  elementId: string;
+  displayMode: DisplayMode;
+  props: Record<string, any>;
+};
+
+export const elementLibrary: ElementDefinition[] = [
+  {
+    id: "title",
+    label: "Title",
+    type: "text",
+    displayModes: ["display"],
+    defaultProps: { label: "Sample Title" },
+    validation: { required: true },
+  },
+  {
+    id: "description",
+    label: "Description",
+    type: "text",
+    displayModes: ["display"],
+    defaultProps: { label: "Sample description" },
+  },
+  {
+    id: "image",
+    label: "Image",
+    type: "image",
+    displayModes: ["display"],
+    defaultProps: {
+      src: "https://via.placeholder.com/300x100?text=Image",
+      alt: "sample image",
+    },
+  },
+  {
+    id: "input",
+    label: "Input Field",
+    type: "text",
+    displayModes: ["input"],
+    defaultProps: { label: "Field", placeholder: "Enter text" },
+    validation: { required: false },
+  },
+  {
+    id: "button",
+    label: "Button",
+    type: "button",
+    displayModes: ["display"],
+    defaultProps: { label: "Click" },
+  },
+];

--- a/packages/card-builder/src/export-helpers.ts
+++ b/packages/card-builder/src/export-helpers.ts
@@ -1,0 +1,88 @@
+import { ElementInstance, elementLibrary, DisplayMode } from "./elements";
+import { generateOpenApi } from "./exportApi";
+
+export interface CardConfig {
+  name: string;
+  elements: ElementInstance[];
+  theme: string;
+  shadow: string;
+  lighting: string;
+  animation: string;
+}
+
+export function buildConfig({
+  name,
+  elements,
+  theme,
+  shadow,
+  lighting,
+  animation,
+}: CardConfig) {
+  return {
+    name,
+    theme,
+    shadow,
+    lighting,
+    animation,
+    elements: elements.map((el) => ({
+      id: el.id,
+      elementId: el.elementId,
+      displayMode: el.displayMode,
+      props: el.props,
+    })),
+  };
+}
+
+export function parseConfig(json: string): CardConfig | null {
+  try {
+    const obj = JSON.parse(json);
+    if (!obj || typeof obj !== "object") return null;
+    const elements: ElementInstance[] = Array.isArray(obj.elements)
+      ? obj.elements
+          .map((el: any) => {
+            const def = elementLibrary.find((d) => d.id === el.elementId);
+            if (!def) return null;
+            const mode: DisplayMode = def.displayModes.includes(el.displayMode)
+              ? el.displayMode
+              : def.displayModes[0];
+            return {
+              id: el.id || Date.now().toString(),
+              elementId: def.id,
+              displayMode: mode,
+              props: el.props || {},
+            };
+          })
+          .filter(Boolean as any)
+      : [];
+    return {
+      name: typeof obj.name === "string" ? obj.name : "Untitled Card",
+      elements,
+      theme: obj.theme || "light",
+      shadow: obj.shadow || "none",
+      lighting: obj.lighting || "none",
+      animation: obj.animation || "none",
+    };
+  } catch (e) {
+    return null;
+  }
+}
+
+export function exportAssets(config: CardConfig) {
+  const data = JSON.stringify(config, null, 2);
+  const jsonBlob = new Blob([data], { type: "application/json" });
+  const jsonUrl = URL.createObjectURL(jsonBlob);
+  const jsonLink = document.createElement("a");
+  jsonLink.href = jsonUrl;
+  jsonLink.download = "card.json";
+  jsonLink.click();
+  URL.revokeObjectURL(jsonUrl);
+
+  const yaml = generateOpenApi(config);
+  const yamlBlob = new Blob([yaml], { type: "application/yaml" });
+  const yamlUrl = URL.createObjectURL(yamlBlob);
+  const yamlLink = document.createElement("a");
+  yamlLink.href = yamlUrl;
+  yamlLink.download = "card.yaml";
+  yamlLink.click();
+  URL.revokeObjectURL(yamlUrl);
+}

--- a/packages/card-builder/src/exportApi.ts
+++ b/packages/card-builder/src/exportApi.ts
@@ -1,4 +1,4 @@
-import type { CardConfig } from "./Editor";
+import type { CardConfig } from "./export-helpers";
 
 // Convert a CardConfig into an OpenAPI 3.0 YAML document.
 // Each interactive element gets a minimal POST endpoint so consumers

--- a/packages/card-builder/src/hooks/useDragAndDrop.ts
+++ b/packages/card-builder/src/hooks/useDragAndDrop.ts
@@ -1,0 +1,71 @@
+import { useState } from "react";
+import { arrayMove, DragEndEvent } from "@dnd-kit/sortable";
+import { ElementInstance, elementLibrary, DisplayMode } from "../elements";
+
+export function useDragAndDrop(initial: ElementInstance[] = []) {
+  const [elements, setElements] = useState<ElementInstance[]>(initial);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { over, active } = event;
+    if (!over) return;
+
+    if (active.data.current?.from === "palette" && over.id === "card") {
+      const def = elementLibrary.find((d) => d.id === active.id);
+      if (!def) return;
+      let mode: DisplayMode = def.displayModes[0];
+      if (def.displayModes.length > 1) {
+        const input = window.prompt(
+          `Display mode (${def.displayModes.join(",")}):`,
+          def.displayModes[0],
+        );
+        if (input && def.displayModes.includes(input as DisplayMode)) {
+          mode = input as DisplayMode;
+        }
+      }
+      const instance: ElementInstance = {
+        id: Date.now().toString(),
+        elementId: def.id,
+        displayMode: mode,
+        props: { ...def.defaultProps },
+      };
+      setElements((els) => [...els, instance]);
+      return;
+    }
+
+    if (active.data.current?.from === "card" && over.id !== "card") {
+      const oldIndex = elements.findIndex((el) => el.id === active.id);
+      const newIndex = elements.findIndex((el) => el.id === over.id);
+      if (oldIndex !== -1 && newIndex !== -1 && oldIndex !== newIndex) {
+        setElements((els) => arrayMove(els, oldIndex, newIndex));
+      }
+    }
+  };
+
+  const removeElement = (id: string) => {
+    setElements((els) => els.filter((el) => el.id !== id));
+    if (selectedId === id) setSelectedId(null);
+  };
+
+  const selected = elements.find((el) => el.id === selectedId) || null;
+
+  const updateSelected = (props: Record<string, any>) => {
+    if (!selected) return;
+    setElements((els) =>
+      els.map((el) =>
+        el.id === selected.id ? { ...el, props: { ...el.props, ...props } } : el,
+      ),
+    );
+  };
+
+  return {
+    elements,
+    setElements,
+    selectedId,
+    setSelectedId,
+    handleDragEnd,
+    removeElement,
+    selected,
+    updateSelected,
+  };
+}

--- a/packages/card-builder/src/palette.tsx
+++ b/packages/card-builder/src/palette.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { useDraggable } from "@dnd-kit/core";
+import { CSS } from "@dnd-kit/utilities";
+import { ElementDefinition } from "./elements";
+
+function PaletteItem({ def }: { def: ElementDefinition }) {
+  const { attributes, listeners, setNodeRef, transform } = useDraggable({
+    id: def.id,
+    data: { from: "palette" },
+  });
+  const style = {
+    transform: CSS.Translate.toString(transform),
+  };
+  return (
+    <div
+      ref={setNodeRef}
+      {...listeners}
+      {...attributes}
+      style={style}
+      className="border p-2 mb-2 cursor-move bg-gray-200 text-sm"
+    >
+      {def.label}
+    </div>
+  );
+}
+
+export function Palette({ elements }: { elements: ElementDefinition[] }) {
+  return <div>{elements.map((def) => <PaletteItem key={def.id} def={def} />)}</div>;
+}

--- a/packages/card-builder/src/properties-panel.tsx
+++ b/packages/card-builder/src/properties-panel.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import { ElementInstance } from "./elements";
+
+export function PropertiesPanel({
+  selected,
+  updateSelected,
+}: {
+  selected: ElementInstance | null;
+  updateSelected: (props: Record<string, any>) => void;
+}) {
+  if (!selected) return null;
+  return (
+    <div className="border p-2 w-96">
+      <div className="mb-2 font-bold">Element Properties</div>
+      <div className="flex flex-col gap-2">
+        <label className="flex gap-2 items-center">
+          <span className="w-24">Label</span>
+          <input
+            className="border px-2 py-1 flex-1"
+            value={selected.props.label || ""}
+            onChange={(e) => updateSelected({ label: e.target.value })}
+          />
+        </label>
+        {selected.displayMode === "input" && (
+          <label className="flex gap-2 items-center">
+            <span className="w-24">Placeholder</span>
+            <input
+              className="border px-2 py-1 flex-1"
+              value={selected.props.placeholder || ""}
+              onChange={(e) => updateSelected({ placeholder: e.target.value })}
+            />
+          </label>
+        )}
+        {selected.elementId === "image" && (
+          <label className="flex gap-2 items-center">
+            <span className="w-24">Image URL</span>
+            <input
+              className="border px-2 py-1 flex-1"
+              value={selected.props.src || ""}
+              onChange={(e) => updateSelected({ src: e.target.value })}
+            />
+          </label>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Extract element definitions and drag-and-drop hooks
- Split card editor into palette, canvas and properties panel components
- Centralize config export helpers and adjust OpenAPI helper

## Testing
- `npm test`
- `npm run check` *(fails: Cannot find name 'siteAccessControl', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68bb46ccf52883319fe01baf190ccc30