### PR TITLE
test: ensure card rename persists

### DIFF
--- a/packages/card-builder/src/__tests__/rename.test.tsx
+++ b/packages/card-builder/src/__tests__/rename.test.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Provide minimal implementations for UI components used in CardBuilderApp
+vi.mock('@/components/ui/card', () => ({
+  Card: (props: any) => <div {...props} />,
+  CardHeader: (props: any) => <div {...props} />,
+  CardTitle: (props: any) => <div {...props} />,
+  CardDescription: (props: any) => <div {...props} />,
+  CardContent: (props: any) => <div {...props} />,
+}), { virtual: true });
+
+vi.mock('@/components/ui/button', () => ({
+  Button: (props: any) => <button {...props} />,
+}), { virtual: true });
+
+import { CardBuilderApp } from '../App';
+
+
+describe('packages/card-builder rename flow', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('updates card name through editor and persists via saveCard', async () => {
+    const initialCard = {
+      id: '1',
+      name: 'Default Card',
+      elements: [],
+      theme: 'light',
+      shadow: 'none',
+      lighting: 'none',
+      animation: 'none',
+    };
+    localStorage.setItem('cards', JSON.stringify([initialCard]));
+
+    const setItemSpy = vi.spyOn(Storage.prototype, 'setItem');
+
+    render(<CardBuilderApp />);
+
+    // ensure initial name rendered
+    expect(screen.getByText('Default Card')).toBeTruthy();
+
+    // open editor
+    fireEvent.click(screen.getByText('Edit'));
+
+    // rename card
+    const input = screen.getByDisplayValue('Default Card') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'Renamed Card' } });
+
+    // save changes
+    fireEvent.click(screen.getByText('Save'));
+
+    // CardBuilderApp should display updated name
+    await screen.findByText('Renamed Card');
+    expect(screen.getByText('Renamed Card')).toBeTruthy();
+
+    // saveCard should persist updated name to localStorage
+    expect(setItemSpy).toHaveBeenLastCalledWith(
+      'cards',
+      expect.stringContaining('Renamed Card'),
+    );
+    const stored = JSON.parse(localStorage.getItem('cards')!);
+    expect(stored[0].name).toBe('Renamed Card');
+
+    setItemSpy.mockRestore();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add rename flow test verifying CardEditor saves to localStorage and CardBuilderApp shows updated name

## Testing
- `npm test packages/card-builder`
- `npx vitest run packages/card-builder/src/__tests__/rename.test.tsx --root packages/card-builder`


------
https://chatgpt.com/codex/tasks/task_e_68bb4c0de46883319c4b065aa587e423