### PR TITLE
test(card-builder): add naming and export tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist && tsx scripts/build-openapi.ts",
     "start": "cross-env NODE_ENV=production node dist/index.js",
     "check": "tsc",
-    "test": "vitest run",
+    "test": "npm run test:unit && npm run test:playwright",
+    "test:unit": "vitest run && vitest run packages/card-builder/src/__tests__/config.test.ts --dir packages/card-builder",
     "test:playwright": "playwright test",
     "db:push": "drizzle-kit push",
     "pre-commit": "node scripts/check-persona-updates.js"

--- a/packages/card-builder/src/__tests__/config.test.ts
+++ b/packages/card-builder/src/__tests__/config.test.ts
@@ -20,6 +20,12 @@ describe('card builder config', () => {
     expect(parsed?.name).toBe('My Card');
   });
 
+  it('assigns default name when missing', () => {
+    const json = JSON.stringify({ elements: [], ...base });
+    const parsed = parseConfig(json);
+    expect(parsed?.name).toBe('Untitled Card');
+  });
+
   it('generates OpenAPI YAML with card name and button path', () => {
     const cfg = buildConfig({
       name: 'My Card',

--- a/playwright/index.html
+++ b/playwright/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Component Tests</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- cover default card name in config tests
- wire unit and Playwright tests through npm scripts
- add Playwright HTML template for component tests

## Testing
- `npm run test:unit`
- `npm run test:playwright` *(fails: Component testing could not determine base URL)*

------
https://chatgpt.com/codex/tasks/task_e_68bb4b9566cc8331bb0d70a5b704befc