### PR TITLE
feat: expose function metadata API

### DIFF
--- a/packages/code-explorer/Tech_Lead-Jordan_Rowe.md
+++ b/packages/code-explorer/Tech_Lead-Jordan_Rowe.md
@@ -68,3 +68,9 @@ Coordinating integration of code exploration features while aligning documentati
 
 ## 🚨 Urgent Notes
 
+
+## 🔄 Status
+- **Past:** Finalized initial AST index design and integrated CodeMirror editors.
+- **Current:** Exposing function metadata through `/code-explorer/api/functions`.
+- **Future:** Experiment with incremental parsing to scale indexing across large repositories.
+

--- a/packages/code-explorer/__tests__/functions.test.ts
+++ b/packages/code-explorer/__tests__/functions.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import express from "express";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { createFunctionsRouter } from "../../../server/functions";
+
+let repoDir: string;
+
+beforeAll(() => {
+  repoDir = fs.mkdtempSync(path.join(os.tmpdir(), "fn-api-"));
+  fs.writeFileSync(path.join(repoDir, "a.ts"), "function hi(){}\n");
+});
+
+afterAll(() => {
+  fs.rmSync(repoDir, { recursive: true, force: true });
+});
+
+describe("GET /functions", () => {
+  it("returns function metadata", async () => {
+    const app = express();
+    app.use("/functions", createFunctionsRouter(() => repoDir));
+    const server = app.listen(0);
+    const { port } = server.address() as any;
+    const res = await fetch(`http://localhost:${port}/functions`);
+    const data = await res.json();
+    server.close();
+    expect(res.status).toBe(200);
+    expect(data).toEqual([
+      { name: "hi", signature: "hi(): any", path: "a.ts", tags: [] },
+    ]);
+  });
+
+  it("returns 400 when repository is not loaded", async () => {
+    const app = express();
+    app.use("/functions", createFunctionsRouter(() => null));
+    const server = app.listen(0);
+    const { port } = server.address() as any;
+    const res = await fetch(`http://localhost:${port}/functions`);
+    server.close();
+    expect(res.status).toBe(400);
+  });
+});

--- a/server/explorer.ts
+++ b/server/explorer.ts
@@ -10,13 +10,15 @@ import open from "open";
 import { setupViteFor, log } from "./vite";
 import { buildFileTree } from "../packages/code-explorer/file-tree.js";
 import { applyPatchToFile } from "./save";
-
+import { createFunctionsRouter } from "./functions";
 const exec = promisify(execCb);
 
 const app = express();
 app.use(express.json());
 
 let currentRepoDir: string | null = null;
+
+app.use("/code-explorer/api/functions", createFunctionsRouter(() => currentRepoDir));
 
 /**
 {

--- a/server/functions.ts
+++ b/server/functions.ts
@@ -1,0 +1,31 @@
+import express from "express";
+import { scan } from "../packages/code-explorer/scan.js";
+
+/**
+{
+  "friendlyName": "functions route",
+  "description": "Exposes parsed function metadata for the active repository.",
+  "editCount": 1,
+  "tags": ["express", "route"],
+  "location": "server/functions.ts > createFunctionsRouter",
+  "notes": "Requires the repository to be cloned before use."
+}
+*/
+export function createFunctionsRouter(getRepoDir: () => string | null) {
+  const router = express.Router();
+
+  router.get("/", (req, res) => {
+    const dir = getRepoDir();
+    if (!dir) {
+      return res.status(400).json({ error: "Repository not loaded" });
+    }
+    try {
+      const data = scan(dir);
+      res.json(data);
+    } catch (err: any) {
+      res.status(500).json({ error: err.message });
+    }
+  });
+
+  return router;
+}


### PR DESCRIPTION
## Summary
- serve function metadata from new `/code-explorer/api/functions` endpoint
- document AST index progress in Tech Lead notes
- test function metadata API for valid and missing repository cases

## Testing
- `npm test`
- `npx vitest run packages/code-explorer/__tests__/functions.test.ts --config packages/code-explorer/vitest.config.ts`
- `npx vitest run --root packages/code-explorer` *(fails: Objects are not valid as a React child)*

------
https://chatgpt.com/codex/tasks/task_e_68bb5156f7c08331a928a2ced196030d