### PR TITLE
feat: add function browser with drag-and-drop integration

### DIFF
--- a/packages/code-explorer/Frontend_Developer-Simon_Hesher.md
+++ b/packages/code-explorer/Frontend_Developer-Simon_Hesher.md
@@ -34,6 +34,8 @@ drag-and-drop libraries, and dependency graph automation.
   symlinks and files without extensions.
 - Implemented a plain-text fallback in FileViewer when CodeMirror or a grammar
   fails to load; updated component state docs and tests.
+- Built a Function Browser component that fetches functions from the new API
+  and supports drag-and-drop into the Composition Canvas; added tests.
 
 ## 🔮 Future Designs
 - Cross-fade transitions when switching between the Function Browser, Canvas, and Code Pane.

--- a/packages/code-explorer/src/App.test.tsx
+++ b/packages/code-explorer/src/App.test.tsx
@@ -5,6 +5,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { CodeExplorerApp } from "./App";
 vi.mock("./components/FileViewer", () => ({ FileViewer: ({ path }: any) => <div>{path}</div> }));
 vi.mock("./components/CompositionCanvas", () => ({ CompositionCanvas: () => <div /> }));
+vi.mock("./components/FunctionBrowser", () => ({ FunctionBrowser: () => <div /> }));
 
 vi.mock("prismjs", () => ({
   default: { highlightAll: vi.fn(), highlight: (code: string) => code, languages: { tsx: {} } },

--- a/packages/code-explorer/src/App.tsx
+++ b/packages/code-explorer/src/App.tsx
@@ -18,6 +18,7 @@ import {
   CompositionNode,
   Edge,
 } from "./components/CompositionCanvas";
+import { FunctionBrowser } from "./components/FunctionBrowser";
 
 /**
 {
@@ -209,7 +210,6 @@ export function CodeExplorerApp() {
 
   if (screen === "explorer") {
     const activePath = tabs[active];
-    const relative = activePath && tree ? activePath.replace(tree.path + "/", "") : null;
     return (
       <div className="flex h-screen">
         <div className="w-64 border-r p-2 flex flex-col">
@@ -265,9 +265,9 @@ export function CodeExplorerApp() {
                 </div>
                 {activePath && <FileViewer path={activePath} />}
               </div>
-              <div className="w-1/2 border-l pl-4">
+              <div className="w-1/2 border-l pl-4 flex">
+                <FunctionBrowser />
                 <CompositionCanvas
-                  functions={relative ? [relative] : []}
                   nodes={composition.nodes}
                   connections={composition.connections}
                   onUpdate={setComposition}

--- a/packages/code-explorer/src/components/CompositionCanvas.test.tsx
+++ b/packages/code-explorer/src/components/CompositionCanvas.test.tsx
@@ -5,11 +5,9 @@ import { describe, it, expect } from "vitest";
 import { CompositionCanvas, CompositionNode, Edge } from "./CompositionCanvas";
 
 function Wrapper({
-  functions = [],
   initialNodes = [],
   initialConnections = [],
 }: {
-  functions?: string[];
   initialNodes?: CompositionNode[];
   initialConnections?: Edge[];
 }) {
@@ -19,7 +17,6 @@ function Wrapper({
   });
   return (
     <CompositionCanvas
-      functions={functions}
       nodes={state.nodes}
       connections={state.connections}
       onUpdate={setState}
@@ -29,15 +26,9 @@ function Wrapper({
 
 describe("CompositionCanvas", () => {
   it("places node on canvas when dropped", () => {
-    render(<Wrapper functions={["fn"]} />);
-    const palette = screen.getByTestId("palette-fn");
+    render(<Wrapper />);
     const canvas = screen.getByTestId("canvas");
 
-    fireEvent.dragStart(palette, {
-      dataTransfer: {
-        setData: () => {},
-      },
-    });
     fireEvent.dragOver(canvas, { preventDefault: () => {} });
     fireEvent.drop(canvas, {
       dataTransfer: { getData: () => "fn" },
@@ -54,13 +45,7 @@ describe("CompositionCanvas", () => {
       { id: "a", name: "A", x: 0, y: 0 },
       { id: "b", name: "B", x: 150, y: 0 },
     ];
-    render(
-      <Wrapper
-        functions={[]}
-        initialNodes={nodes}
-        initialConnections={[]}
-      />
-    );
+    render(<Wrapper initialNodes={nodes} initialConnections={[]} />);
 
     fireEvent.click(screen.getByTestId("output-a"));
     fireEvent.click(screen.getByTestId("input-b"));

--- a/packages/code-explorer/src/components/CompositionCanvas.tsx
+++ b/packages/code-explorer/src/components/CompositionCanvas.tsx
@@ -14,7 +14,6 @@ export interface Edge {
 }
 
 interface Props {
-  functions: string[];
   nodes: CompositionNode[];
   connections: Edge[];
   onUpdate(state: { nodes: CompositionNode[]; connections: Edge[] }): void;
@@ -23,7 +22,7 @@ interface Props {
 /**
  * Basic composition canvas allowing drag-and-drop of function nodes and wiring.
  */
-export function CompositionCanvas({ functions, nodes, connections, onUpdate }: Props) {
+export function CompositionCanvas({ nodes, connections, onUpdate }: Props) {
   const [localNodes, setLocalNodes] = useState<CompositionNode[]>(nodes);
   const [localConnections, setLocalConnections] = useState<Edge[]>(connections);
   const [pending, setPending] = useState<string | null>(null);
@@ -32,10 +31,6 @@ export function CompositionCanvas({ functions, nodes, connections, onUpdate }: P
     setLocalNodes(nodes);
     setLocalConnections(connections);
   }, [nodes, connections]);
-
-  function handleDragStart(e: React.DragEvent<HTMLDivElement>, fn: string) {
-    e.dataTransfer.setData("text/plain", fn);
-  }
 
   function handleDrop(e: React.DragEvent<HTMLDivElement>) {
     e.preventDefault();
@@ -69,70 +64,55 @@ export function CompositionCanvas({ functions, nodes, connections, onUpdate }: P
   }
 
   return (
-    <div className="flex h-full">
-      <div className="w-32 border-r p-2">
-        {functions.map((fn) => (
-          <div
-            key={fn}
-            draggable
-            data-testid={`palette-${fn}`}
-            onDragStart={(e) => handleDragStart(e, fn)}
-            className="p-2 mb-2 border rounded bg-background cursor-move text-xs"
-          >
-            {fn}
+    <div
+      className="flex-1 relative bg-white"
+      data-testid="canvas"
+      onDrop={handleDrop}
+      onDragOver={handleDragOver}
+    >
+      <svg className="absolute inset-0 pointer-events-none">
+        {localConnections.map((c) => {
+          const from = localNodes.find((n) => n.id === c.from);
+          const to = localNodes.find((n) => n.id === c.to);
+          if (!from || !to) return null;
+          const x1 = from.x + 120;
+          const y1 = from.y + 25;
+          const x2 = to.x;
+          const y2 = to.y + 25;
+          return (
+            <line
+              key={`${c.from}-${c.to}`}
+              data-testid={`edge-${c.from}-${c.to}`}
+              x1={x1}
+              y1={y1}
+              x2={x2}
+              y2={y2}
+              stroke="black"
+            />
+          );
+        })}
+      </svg>
+      {localNodes.map((n) => (
+        <div
+          key={n.id}
+          className="absolute border rounded p-2 bg-background text-xs"
+          style={{ left: n.x, top: n.y, width: 120 }}
+        >
+          <div>{n.name}</div>
+          <div className="flex justify-between mt-2">
+            <div
+              className="w-3 h-3 bg-blue-500 rounded-full cursor-pointer"
+              data-testid={`input-${n.id}`}
+              onClick={() => finishConnection(n.id)}
+            />
+            <div
+              className="w-3 h-3 bg-green-500 rounded-full cursor-pointer"
+              data-testid={`output-${n.id}`}
+              onClick={() => startConnection(n.id)}
+            />
           </div>
-        ))}
-      </div>
-      <div
-        className="flex-1 relative bg-white"
-        data-testid="canvas"
-        onDrop={handleDrop}
-        onDragOver={handleDragOver}
-      >
-        <svg className="absolute inset-0 pointer-events-none">
-          {localConnections.map((c) => {
-            const from = localNodes.find((n) => n.id === c.from);
-            const to = localNodes.find((n) => n.id === c.to);
-            if (!from || !to) return null;
-            const x1 = from.x + 120;
-            const y1 = from.y + 25;
-            const x2 = to.x;
-            const y2 = to.y + 25;
-            return (
-              <line
-                key={`${c.from}-${c.to}`}
-                data-testid={`edge-${c.from}-${c.to}`}
-                x1={x1}
-                y1={y1}
-                x2={x2}
-                y2={y2}
-                stroke="black"
-              />
-            );
-          })}
-        </svg>
-        {localNodes.map((n) => (
-          <div
-            key={n.id}
-            className="absolute border rounded p-2 bg-background text-xs"
-            style={{ left: n.x, top: n.y, width: 120 }}
-          >
-            <div>{n.name}</div>
-            <div className="flex justify-between mt-2">
-              <div
-                className="w-3 h-3 bg-blue-500 rounded-full cursor-pointer"
-                data-testid={`input-${n.id}`}
-                onClick={() => finishConnection(n.id)}
-              />
-              <div
-                className="w-3 h-3 bg-green-500 rounded-full cursor-pointer"
-                data-testid={`output-${n.id}`}
-                onClick={() => startConnection(n.id)}
-              />
-            </div>
-          </div>
-        ))}
-      </div>
+        </div>
+      ))}
     </div>
   );
 }

--- a/packages/code-explorer/src/components/FunctionBrowser.test.tsx
+++ b/packages/code-explorer/src/components/FunctionBrowser.test.tsx
@@ -1,0 +1,81 @@
+/* @vitest-environment jsdom */
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { FunctionBrowser } from "./FunctionBrowser";
+import { CompositionCanvas, CompositionNode, Edge } from "./CompositionCanvas";
+
+describe("FunctionBrowser", () => {
+  it("filters displayed functions", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      json: () =>
+        Promise.resolve([
+          { name: "foo", signature: "", path: "a.ts", tags: [] },
+          { name: "bar", signature: "", path: "b.ts", tags: [] },
+        ]),
+    } as any);
+
+    render(<FunctionBrowser />);
+
+    await screen.findByTestId("function-foo");
+
+    fireEvent.change(screen.getByTestId("function-search"), {
+      target: { value: "bar" },
+    });
+
+    expect(screen.queryByTestId("function-foo")).toBeNull();
+    expect(screen.getByTestId("function-bar")).toBeTruthy();
+  });
+
+  it("drags function to composition canvas", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      json: () =>
+        Promise.resolve([
+          { name: "foo", signature: "", path: "a.ts", tags: [] },
+        ]),
+    } as any);
+
+    function Wrapper() {
+      const [state, setState] = React.useState({
+        nodes: [] as CompositionNode[],
+        connections: [] as Edge[],
+      });
+      return (
+        <div className="flex">
+          <FunctionBrowser />
+          <CompositionCanvas
+            nodes={state.nodes}
+            connections={state.connections}
+            onUpdate={setState}
+          />
+        </div>
+      );
+    }
+
+    render(<Wrapper />);
+
+    const item = await screen.findByTestId("function-foo");
+    const canvas = screen.getByTestId("canvas");
+
+    const data: Record<string, string> = {};
+    fireEvent.dragStart(item, {
+      dataTransfer: {
+        setData: (key: string, val: string) => {
+          data[key] = val;
+        },
+      },
+    });
+    fireEvent.dragOver(canvas, { preventDefault: () => {} });
+    fireEvent.drop(canvas, {
+      dataTransfer: {
+        getData: (key: string) => data[key],
+      },
+      clientX: 5,
+      clientY: 5,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("foo")).toBeTruthy();
+    });
+  });
+});

--- a/packages/code-explorer/src/components/FunctionBrowser.tsx
+++ b/packages/code-explorer/src/components/FunctionBrowser.tsx
@@ -1,0 +1,59 @@
+import React, { useEffect, useState } from "react";
+
+export interface FunctionMeta {
+  name: string;
+  signature: string;
+  path: string;
+  tags: string[];
+}
+
+interface Props {
+  onSelect?(fn: FunctionMeta): void;
+}
+
+/**
+ * Displays repository functions and supports dragging them onto the composition canvas.
+ */
+export function FunctionBrowser({ onSelect }: Props) {
+  const [functions, setFunctions] = useState<FunctionMeta[]>([]);
+  const [query, setQuery] = useState("");
+
+  useEffect(() => {
+    fetch("/api/functions")
+      .then((res) => res.json())
+      .then((data) => setFunctions(data))
+      .catch(() => setFunctions([]));
+  }, []);
+
+  const filtered = functions.filter((f) =>
+    f.name.toLowerCase().includes(query.toLowerCase())
+  );
+
+  return (
+    <div className="w-32 border-r p-2" data-testid="function-browser">
+      <input
+        className="mb-2 w-full border rounded px-1 py-0.5 text-xs"
+        placeholder="Search..."
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        data-testid="function-search"
+      />
+      {filtered.map((fn) => (
+        <div
+          key={`${fn.path}-${fn.name}`}
+          draggable
+          data-testid={`function-${fn.name}`}
+          onDragStart={(e) => {
+            e.dataTransfer.setData("text/plain", fn.name);
+            onSelect?.(fn);
+          }}
+          className="p-2 mb-2 border rounded bg-background cursor-move text-xs"
+        >
+          {fn.name}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default FunctionBrowser;


### PR DESCRIPTION
## Summary
- add FunctionBrowser component that fetches functions from API and allows dragging
- refactor CompositionCanvas to accept external drops and connect to FunctionBrowser
- update explorer app and tests; log progress in developer notes

## Testing
- `npm test`
- `npx vitest run src/components/CompositionCanvas.test.tsx src/components/FunctionBrowser.test.tsx` *(fails: Objects are not valid as a React child)*

------
https://chatgpt.com/codex/tasks/task_e_68bb52d504fc83319b2a6ce914a84a25