### PR TITLE
Add export naming tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start": "cross-env NODE_ENV=production node dist/index.js",
     "check": "tsc",
     "test": "npm run test:unit && npm run test:playwright",
-    "test:unit": "vitest run && vitest run packages/card-builder/src/__tests__/config.test.ts --dir packages/card-builder",
+    "test:unit": "vitest run && vitest run packages/card-builder/src/__tests__/config.test.ts packages/card-builder/src/__tests__/export-assets.test.ts --dir packages/card-builder",
     "test:playwright": "playwright test",
     "db:push": "drizzle-kit push",
     "pre-commit": "node scripts/check-persona-updates.js"

--- a/packages/card-builder/QA_Engineer-Santiago_Morales.md
+++ b/packages/card-builder/QA_Engineer-Santiago_Morales.md
@@ -11,13 +11,15 @@ I have a degree in information systems and several years of experience testing w
 - **[2025‑09‑05]** Joined the Card Builder project to set up its testing framework.  Introduced Jest for unit testing and Cypress for end‑to‑end flows.  Wrote our first smoke tests: opening the editor, dragging elements, saving a card and exporting it.
 - **[2025‑09‑06]** Developed cross‑browser test suites that run on Chromium, Firefox and Safari using a cloud testing service.  Discovered that our neon theme caused contrast issues in Safari.  Filed a bug and made a joke about neon lights in tango bars.
 - **[2025‑09‑07]** Started writing integration tests for the API generator.  Collaborated with Tariq to mock backend responses and validate that exported cards correctly send and receive data.  Danced a celebratory milonga when all tests passed.
+- **[2025‑09‑08]** Added unit and cross-browser tests to ensure card names persist in exported JSON and YAML. Noted that edge cases like special characters still need coverage.
 
 ## What I’m Doing
 
-Currently I’m expanding our test coverage to include more complex multi‑card flows.  I’m scripting scenarios where users create a sequence of cards with conditional navigation and ensuring that exports preserve those relationships.  I’m also adding accessibility checks using axe-core to catch issues like insufficient colour contrast or missing focus indicators.  On the API side, I’m testing error handling: what happens when a generated endpoint returns a 500, or when network latency spikes?  These tests are like rehearsals for worst‑case scenarios.
+With naming and export tests in place, I’m refocusing on complex multi‑card flows. I’m scripting scenarios where users create a sequence of cards with conditional navigation and ensuring exports preserve those relationships. I’m also adding accessibility checks using axe-core to catch issues like insufficient colour contrast or missing focus indicators. On the API side, I’m testing error handling: what happens when a generated endpoint returns a 500, or when network latency spikes? These tests are like rehearsals for worst‑case scenarios.
 
 ## Where I’m Headed
 
-- Develop automated performance testing for exported modules to ensure they load quickly and run smoothly in mobile browsers.
-- Write a testing playbook for contributors, with patterns and anti‑patterns for writing reliable tests.  I might frame it as a script with characters and acts.
-- Integrate visual regression testing to detect unintended changes in the card’s appearance after code changes.  Perhaps I’ll use snapshots like stage photos to compare scenes.
+- Santiago Morales: Develop automated performance testing for exported modules to ensure they load quickly and run smoothly in mobile browsers.
+- Santiago Morales: Write a testing playbook for contributors, with patterns and anti‑patterns for writing reliable tests. I might frame it as a script with characters and acts.
+- Santiago Morales: Integrate visual regression testing to detect unintended changes in the card’s appearance after code changes. Perhaps I’ll use snapshots like stage photos to compare scenes.
+- Santiago Morales: Expand export tests to cover cards with special characters and localized filenames.

--- a/packages/card-builder/src/__tests__/cross-browser.spec.tsx
+++ b/packages/card-builder/src/__tests__/cross-browser.spec.tsx
@@ -11,7 +11,7 @@ test('exports assets with current card name', async ({ mount, page }) => {
   await mount(<CardEditor onSave={() => {}} onBack={() => {}} />);
   await page.locator('input').first().fill('Cross Browser Card');
 
-  const exportButton = page.getByText('Export JSON');
+  const exportButton = page.getByText('Export Assets');
   const [jsonDownload, yamlDownload] = await Promise.all([
     page.waitForEvent('download'),
     page.waitForEvent('download'),

--- a/packages/card-builder/src/__tests__/default-name.spec.tsx
+++ b/packages/card-builder/src/__tests__/default-name.spec.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import fs from 'node:fs/promises';
+import { test, expect } from '@playwright/experimental-ct-react';
+import { CardEditor } from '../Editor';
+
+// Ensure default naming is preserved when exporting across browsers
+// Playwright config runs this spec in Chromium, Firefox and WebKit
+
+test('exports assets with default card name', async ({ mount, page }) => {
+  await mount(<CardEditor onSave={() => {}} onBack={() => {}} />);
+  await page.locator('input').first().fill('');
+
+  const exportButton = page.getByText('Export Assets');
+  const [jsonDownload, yamlDownload] = await Promise.all([
+    page.waitForEvent('download'),
+    page.waitForEvent('download'),
+    exportButton.click(),
+  ]);
+
+  const jsonContent = await fs.readFile(await jsonDownload.path()!, 'utf-8');
+  const yamlContent = await fs.readFile(await yamlDownload.path()!, 'utf-8');
+
+  expect(jsonContent).toContain('"name": "Untitled Card"');
+  expect(yamlContent).toContain('title: "Untitled Card"');
+});

--- a/packages/card-builder/src/__tests__/export-assets.test.ts
+++ b/packages/card-builder/src/__tests__/export-assets.test.ts
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../exportApi', () => ({
+  generateOpenApi: vi.fn(() => 'openapi: "3.0.0"'),
+}));
+
+import { exportAssets, type CardConfig } from '../export-utils';
+import { generateOpenApi } from '../exportApi';
+
+describe('exportAssets', () => {
+  it('generates JSON and YAML downloads using card name', () => {
+    const cfg: CardConfig = {
+      name: 'Unit Test Card',
+      elements: [],
+      theme: 'light',
+      shadow: 'none',
+      lighting: 'none',
+      animation: 'none',
+    };
+
+    const createObjectURL = vi.fn(() => 'blob:url');
+    const revokeObjectURL = vi.fn();
+    const origCreate = URL.createObjectURL;
+    const origRevoke = URL.revokeObjectURL;
+    (URL as any).createObjectURL = createObjectURL;
+    (URL as any).revokeObjectURL = revokeObjectURL;
+
+    const anchors: any[] = [];
+    vi.spyOn(document, 'createElement').mockImplementation(() => {
+      const anchor = { href: '', download: '', click: vi.fn() } as any;
+      anchors.push(anchor);
+      return anchor;
+    });
+
+    exportAssets(cfg);
+
+    expect(createObjectURL).toHaveBeenCalledTimes(2);
+    expect(generateOpenApi).toHaveBeenCalledWith(cfg);
+    expect(anchors[0].download).toBe('card.json');
+    expect(anchors[1].download).toBe('card.yaml');
+    expect(anchors[0].click).toHaveBeenCalled();
+    expect(anchors[1].click).toHaveBeenCalled();
+
+    (URL as any).createObjectURL = origCreate;
+    (URL as any).revokeObjectURL = origRevoke;
+  });
+});


### PR DESCRIPTION
## Summary
- add unit test ensuring `exportAssets` produces JSON and YAML downloads
- add cross-browser tests verifying card names in exports
- wire new tests into `npm test` and update QA persona notes

## Testing
- `npm test` *(fails: missing Playwright browser dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68bb54c6b02c83318090ab4a25216a01