### PR TITLE
docs: add exporting and style guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mining Syndicate Platform
 
-See [Onboarding Guide](docs/onboarding.md) for setup, tests, and profile conventions. Install CodeMirror and its language packages with `npm install` so code snippets can be highlighted.
+See [Onboarding Guide](docs/onboarding.md) for setup, tests, and profile conventions. Consult [Exporting Cards](docs/exporting-cards.md) to turn Card Builder creations into reusable modules, and follow our [Documentation Style Guide](docs/style-guide.md). Install CodeMirror and its language packages with `npm install` so code snippets can be highlighted.
 
 ## Development
 

--- a/docs/exporting-cards.md
+++ b/docs/exporting-cards.md
@@ -1,0 +1,22 @@
+# Exporting Cards
+
+Turn a Card Builder creation into a reusable module that ships with its own API contract.
+
+## Before you start
+- Start the Card Builder locally:
+  ```bash
+  npm run card-builder
+  ```
+- Design your card on the canvas.
+
+## Export
+1. Click **Export** in the toolbar.
+2. Choose your preferred format (React component or Web Component).
+3. Download the bundle. It includes:
+   - the component source;
+   - an OpenAPI spec describing generated endpoints.
+
+## Next steps
+- Import the component into your application.
+- Wire the documented endpoints to your backend.
+- Need writing tips? See the [Documentation Style Guide](./style-guide.md).

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,0 +1,15 @@
+# Documentation Style Guide
+
+Consistency keeps our guides accessible and easy to maintain. Follow these conventions when writing.
+
+## Tone
+- Address the reader as "you" and use active voice.
+- Prefer short sentences and everyday language.
+
+## Formatting
+- Start each page with an H1 title.
+- Use sentence case for headings.
+- Wrap commands and code samples in fenced blocks.
+
+## Cross-links
+- Connect related topics. For export instructions, see [Exporting Cards](./exporting-cards.md).

--- a/packages/card-builder/Technical_Writer-Morgan_Lee.md
+++ b/packages/card-builder/Technical_Writer-Morgan_Lee.md
@@ -8,10 +8,15 @@ Card Builder drew me in because every exported card is both prop and protagonist
 ## My Story So Far
 - **[2025-09-08]** Joined the ensemble to script our API stories and ensure each card’s backstage is well lit for developers.
 
+- **[2025-09-12]** Drafted the exporting guide and codified our documentation style so future writers hit the stage in sync.
+
 ## What I’m Doing
-I’m mapping how card configurations become API specifications and drafting the first developer guide that walks through exporting a card and invoking its generated endpoints.
+
+I'm polishing the exporting cards tutorial and humming through the new style guide, inviting the team to add their verses.
 
 ## Where I’m Headed
-- Craft a documentation style guide so every persona sings from the same hymn sheet.
-- Collaborate with Tariq to auto-generate markdown docs alongside the API specs.
-- Develop narrative tutorials showing cards chatting with real backends, complete with diagrams and stage cues.
+
+- Morgan Lee: Read AGENT.md
+- Morgan Lee: Gather feedback on the style guide and fold it into future docs.
+- Morgan Lee: Collaborate with Tariq to auto-generate markdown docs alongside the API specs.
+- Morgan Lee: Develop narrative tutorials showing cards chatting with real backends, complete with diagrams and stage cues.


### PR DESCRIPTION
## Summary
- document how to export cards and reuse the generated modules
- add documentation style guide
- link new guides from README and update Morgan Lee's persona

## Testing
- `npm test` (fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/webkit-2203/pw_run.sh)
- `npm run pre-commit`


------
https://chatgpt.com/codex/tasks/task_e_68bb565199008331906905d30ffdb8f9