### PR TITLE
feat(card-builder): allow deleting saved cards

### DIFF
--- a/packages/card-builder/Frontend_Developer-Casey_Rivera.md
+++ b/packages/card-builder/Frontend_Developer-Casey_Rivera.md
@@ -13,13 +13,15 @@ I adore crafting interactions that feel tactile and alive.  Animations, responsi
 - **[2025‑09‑07]** Built the first version of the preview mode, toggling between design and presentation views.  Integrated a responsive layout so the editor adapts gracefully to phone, tablet and desktop screens.
 - **[2025-09-08]** Threaded a new card-name field through the editor, save flow and preview so every card wears its title proudly.  Felt like giving each creation its own signature.
 - **[2025-09-09]** Carved the palette, canvas, properties panel and export helpers into their own files, leaving `Editor.tsx` as a slim conductor.
+- **[2025-09-10]** Added a delete control beside each saved card so creators can sweep away drafts with a quick confirmation.
 
 ## What I’m Doing
 
-Now that the editor’s pieces live in their own files, I’m circling back to refining the properties panel to be more intuitive.  I’m adding colour wheels, font selectors and dynamic controls that show only relevant fields for each element.  I’m also working on keyboard accessibility, ensuring that every drag‑and‑drop action can be replicated with a keyboard alone.  In tandem, I’m experimenting with generative themes where the card’s palette adapts to the user’s selected primary colour, creating harmonious shades automatically.  All while listening to salsa beats in the background, of course.
+With card deletion handled, I’m circling back to refining the properties panel to be more intuitive.  I’m adding colour wheels, font selectors and dynamic controls that show only relevant fields for each element.  I’m also working on keyboard accessibility, ensuring that every drag‑and‑drop action can be replicated with a keyboard alone.  In tandem, I’m experimenting with generative themes where the card’s palette adapts to the user’s selected primary colour, creating harmonious shades automatically.  All while listening to salsa beats in the background, of course.
 
 ## Where I’m Headed
 
 - Implement multi‑card linking in the UI, including a flowchart view where users can see how their cards connect.  I imagine lines that curve gracefully like choreographed dancers.
 - Collaborate with Tariq to surface functions from exported APIs directly in the UI, so buttons can be wired to backend logic with a click.
 - Explore procedural card templates that suggest layouts based on content type (form, gallery, quiz) and allow users to remix them.  It’s like providing starter dance routines that users can improvise on.
+- Add undo and redo capabilities so creators can step through their moves like rehearsed choreography.

--- a/packages/card-builder/src/App.tsx
+++ b/packages/card-builder/src/App.tsx
@@ -3,7 +3,7 @@ import { CardEditor, CardConfig, elementLibrary } from "./Editor";
 import { ActionCard } from "./components/ActionCard";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Plus, Edit } from "lucide-react";
+import { Plus, Edit, Trash } from "lucide-react";
 
 interface StoredCard extends CardConfig {
   id: string;
@@ -97,6 +97,15 @@ export function CardBuilderApp() {
   });
   const [editing, setEditing] = useState<StoredCard | null>(null);
 
+  const deleteCard = (id: string) => {
+    if (!window.confirm("Delete this card?")) return;
+    setCards((prev) => {
+      const list = prev.filter((c) => c.id !== id);
+      localStorage.setItem("cards", JSON.stringify(list));
+      return list;
+    });
+  };
+
   const saveCard = (config: CardConfig) => {
     if (!editing) return;
     const updated: StoredCard = { ...editing, ...config };
@@ -145,10 +154,19 @@ export function CardBuilderApp() {
             </CardHeader>
             <CardContent className="space-y-4">
               <PreviewCard card={card} />
-              <Button onClick={() => setEditing(card)}>
-                <Edit className="mr-2 h-4 w-4" />
-                Edit
-              </Button>
+              <div className="flex gap-2">
+                <Button onClick={() => setEditing(card)}>
+                  <Edit className="mr-2 h-4 w-4" />
+                  Edit
+                </Button>
+                <Button
+                  variant="destructive"
+                  onClick={() => deleteCard(card.id)}
+                >
+                  <Trash className="mr-2 h-4 w-4" />
+                  Delete
+                </Button>
+              </div>
             </CardContent>
           </Card>
         ))}


### PR DESCRIPTION
## Summary
- add delete action beside saved cards with confirmation
- log the new cleanup flow in Casey Rivera's persona

## Testing
- `npm test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/...)*
- `npx playwright install` *(fails: Download failed: server returned code 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bb58cec3408331b5a0350bc19cdc9d