### PR TITLE
Harden card storage parsing

### DIFF
--- a/packages/card-builder/Backend_Developer-Tariq_Al-Fulani.md
+++ b/packages/card-builder/Backend_Developer-Tariq_Al-Fulani.md
@@ -12,9 +12,10 @@ For the **Card Builder**, I’m designing the invisible scaffolding: the service
 - **[2025‑09‑06]** Built endpoints for saving, loading and listing cards.  Designed a simple versioning scheme so edits don’t overwrite previous designs.  Discussed API naming conventions with the team over Arabic coffee.
 - **[2025‑09‑07]** Began prototyping the API generator.  Explored both REST and GraphQL output formats and debated their merits with Casey and Riley.  Sketched out how functions imported from Code Explorer might map onto button actions.
 - **[2025‑09‑08]** Refactored the export flow to `exportAssets`, producing both the card's JSON blueprint and an OpenAPI 3 spec via a new `exportApi` module.
+- **[2025‑09‑09]** Hardened card loading by wrapping `localStorage` parsing in `try/catch`, logging corrupt data and offering an inline reset so designers can recover without reloads.
 
 ## What I’m Doing
-Right now I’m polishing the API generator—tuning the OpenAPI output and sketching a plugin system so different runtime targets can extend it.  With the export button now pulling both `card.json` and `card.yaml`, my next focus is hardening validation and wiring serverless deployment hooks.
+Right now I’m polishing the API generator—tuning the OpenAPI output and sketching a plugin system so different runtime targets can extend it.  After adding resilient `localStorage` parsing and inline error reporting, my next focus is hardening validation and wiring serverless deployment hooks.
 
 ## Where I’m Headed
 

--- a/packages/card-builder/src/App.tsx
+++ b/packages/card-builder/src/App.tsx
@@ -91,11 +91,27 @@ function PreviewCard({ card }: { card: StoredCard }) {
 }
 
 export function CardBuilderApp() {
-  const [cards, setCards] = useState<StoredCard[]>(() => {
-    const raw = localStorage.getItem("cards");
-    return raw ? JSON.parse(raw) : [];
-  });
+  const stored = localStorage.getItem("cards");
+  let initialCards: StoredCard[] = [];
+  let initialError: string | null = null;
+  if (stored) {
+    try {
+      initialCards = JSON.parse(stored);
+    } catch (err) {
+      console.error("Failed to parse stored cards", err);
+      initialError = "Stored cards are corrupted. You can reset.";
+    }
+  }
+
+  const [cards, setCards] = useState<StoredCard[]>(initialCards);
+  const [error, setError] = useState<string | null>(initialError);
   const [editing, setEditing] = useState<StoredCard | null>(null);
+
+  const resetStorage = () => {
+    localStorage.removeItem("cards");
+    setCards([]);
+    setError(null);
+  };
 
   const deleteCard = (id: string) => {
     if (!window.confirm("Delete this card?")) return;
@@ -139,6 +155,14 @@ export function CardBuilderApp() {
 
   return (
     <div className="p-8">
+      {error && (
+        <div className="mb-4 p-2 border border-red-500 text-red-700">
+          {error}
+          <Button variant="outline" className="ml-2" onClick={resetStorage}>
+            Reset
+          </Button>
+        </div>
+      )}
       <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
         <ActionCard
           icon={Plus}

--- a/packages/card-builder/src/Editor.tsx
+++ b/packages/card-builder/src/Editor.tsx
@@ -31,6 +31,7 @@ export function CardEditor({
   const [animation, setAnimation] = useState("none");
   const [showCode, setShowCode] = useState(false);
   const [code, setCode] = useState("{}");
+  const [codeError, setCodeError] = useState<string | null>(null);
 
   const {
     elements,
@@ -67,9 +68,11 @@ export function CardEditor({
   const applyCode = () => {
     const parsed = parseConfig(code);
     if (!parsed) {
-      alert("Invalid JSON configuration");
+      console.error("Invalid JSON configuration");
+      setCodeError("Invalid JSON configuration");
       return;
     }
+    setCodeError(null);
     setName(parsed.name);
     setElements(parsed.elements);
     setTheme(parsed.theme);
@@ -178,6 +181,9 @@ export function CardEditor({
             onChange={(e) => setCode(e.target.value)}
             className="border p-2 font-mono h-80"
           />
+          {codeError && (
+            <div className="text-red-600">{codeError}</div>
+          )}
           <div>
             <Button onClick={applyCode} className="mr-2">
               Apply


### PR DESCRIPTION
## Summary
- guard card loading with try/catch and inline reset when localStorage is corrupted
- replace JSON parse alert with inline error messaging
- log failures for easier debugging and update Tariq's journal

## Testing
- `npm test` *(fails: Download failed: server returned code 403 body 'Domain forbidden')*
- `npx playwright install` *(fails: Download failed: server returned code 403 body 'Domain forbidden')*
- `npm run pre-commit`


------
https://chatgpt.com/codex/tasks/task_e_68bb5a263f6c8331b45d85162a70d549