### PR TITLE
feat: fetch functions from new API

### DIFF
--- a/packages/code-explorer/Frontend_Developer-Simon_Hesher.md
+++ b/packages/code-explorer/Frontend_Developer-Simon_Hesher.md
@@ -36,6 +36,8 @@ drag-and-drop libraries, and dependency graph automation.
   fails to load; updated component state docs and tests.
 - Built a Function Browser component that fetches functions from the new API
   and supports drag-and-drop into the Composition Canvas; added tests.
+- Expanded Function Browser tests to cover the new `/code-explorer/api/functions`
+  endpoint and verify selection callbacks during drag events.
 
 ## 🔮 Future Designs
 - Cross-fade transitions when switching between the Function Browser, Canvas, and Code Pane.

--- a/packages/code-explorer/src/components/FunctionBrowser.test.tsx
+++ b/packages/code-explorer/src/components/FunctionBrowser.test.tsx
@@ -148,4 +148,32 @@ describe("FunctionBrowser", () => {
       expect(screen.getByText("bar")).toBeTruthy();
     });
   });
+
+  it("requests functions from explorer API endpoint", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      json: () => Promise.resolve([]),
+    } as any);
+
+    render(<FunctionBrowser />);
+
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+    expect(global.fetch).toHaveBeenCalledWith("/code-explorer/api/functions");
+  });
+
+  it("invokes onSelect when dragging", async () => {
+    const onSelect = vi.fn();
+    const fn = { name: "foo", signature: "", path: "a.ts", tags: [] };
+    global.fetch = vi.fn().mockResolvedValue({
+      json: () => Promise.resolve([fn]),
+    } as any);
+
+    render(<FunctionBrowser onSelect={onSelect} />);
+
+    const item = await screen.findByTestId("function-foo");
+    fireEvent.dragStart(item, {
+      dataTransfer: { setData: () => {} },
+    });
+
+    expect(onSelect).toHaveBeenCalledWith(fn);
+  });
 });

--- a/packages/code-explorer/src/components/FunctionBrowser.tsx
+++ b/packages/code-explorer/src/components/FunctionBrowser.tsx
@@ -19,7 +19,7 @@ export function FunctionBrowser({ onSelect }: Props) {
   const [query, setQuery] = useState("");
 
   useEffect(() => {
-    fetch("/api/functions")
+    fetch("/code-explorer/api/functions")
       .then((res) => res.json())
       .then((data) => setFunctions(data))
       .catch(() => setFunctions([]));


### PR DESCRIPTION
## Summary
- query `/code-explorer/api/functions` for available functions
- extend FunctionBrowser tests for endpoint usage and drag-select callbacks
- log progress in Simon Hesher's profile

## Testing
- `npx vitest run --root packages/code-explorer` *(fails: Objects are not valid as a React child)*

------
https://chatgpt.com/codex/tasks/task_e_68bb5ad5e97c83319d34efde21d0d512