### PR TITLE
feat(card-builder): polish name field and verify deletion

### DIFF
--- a/packages/card-builder/Frontend_Developer-Casey_Rivera.md
+++ b/packages/card-builder/Frontend_Developer-Casey_Rivera.md
@@ -15,9 +15,11 @@ I adore crafting interactions that feel tactile and alive.  Animations, responsi
 - **[2025-09-09]** Carved the palette, canvas, properties panel and export helpers into their own files, leaving `Editor.tsx` as a slim conductor.
 - **[2025-09-10]** Added a delete control beside each saved card so creators can sweep away drafts with a quick confirmation.
 
+- **[2025-09-11]** Polished the editor toolbar with a proper name input that trims stray spaces and falls back to "Untitled Card".  Wrote a safety net test to ensure gallery deletions wipe cards from localStorage as cleanly as a fresh coat of paint.
+
 ## What I’m Doing
 
-With card deletion handled, I’m circling back to refining the properties panel to be more intuitive.  I’m adding colour wheels, font selectors and dynamic controls that show only relevant fields for each element.  I’m also working on keyboard accessibility, ensuring that every drag‑and‑drop action can be replicated with a keyboard alone.  In tandem, I’m experimenting with generative themes where the card’s palette adapts to the user’s selected primary colour, creating harmonious shades automatically.  All while listening to salsa beats in the background, of course.
+With the toolbar’s naming field polished and deletion covered, I’m circling back to refining the properties panel to be more intuitive.  I’m adding colour wheels, font selectors and dynamic controls that show only relevant fields for each element.  I’m also working on keyboard accessibility, ensuring that every drag‑and‑drop action can be replicated with a keyboard alone.  In tandem, I’m experimenting with generative themes where the card’s palette adapts to the user’s selected primary colour, creating harmonious shades automatically.  All while listening to salsa beats in the background, of course.
 
 ## Where I’m Headed
 

--- a/packages/card-builder/src/Editor.tsx
+++ b/packages/card-builder/src/Editor.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { DndContext } from "@dnd-kit/core";
 import { Palette } from "./components/Palette";
 import { CardCanvas } from "./components/CardCanvas";
@@ -56,9 +57,17 @@ export function CardEditor({
   }, [initial, setElements]);
 
   useEffect(() => {
+    const resolvedName = name.trim() || "Untitled Card";
     setCode(
       JSON.stringify(
-        buildConfig({ name, elements, theme, shadow, lighting, animation }),
+        buildConfig({
+          name: resolvedName,
+          elements,
+          theme,
+          shadow,
+          lighting,
+          animation,
+        }),
         null,
         2,
       ),
@@ -85,11 +94,13 @@ export function CardEditor({
   return (
     <div className="p-4 space-y-4 text-sm">
       <div className="flex gap-2 items-center flex-wrap">
-        <label>Card Name:</label>
-        <input
+        <label htmlFor="card-name">Card Name:</label>
+        <Input
+          id="card-name"
           value={name}
           onChange={(e) => setName(e.target.value)}
-          className="border px-2 py-1"
+          className="w-48"
+          placeholder="Untitled Card"
         />
         <label>Theme:</label>
         <select
@@ -137,18 +148,17 @@ export function CardEditor({
 
         <Button onClick={onBack} variant="outline">Back</Button>
         <Button
-          onClick={() =>
-            onSave(
-              buildConfig({
-                name,
-                elements,
-                theme,
-                shadow,
-                lighting,
-                animation,
-              }),
-            )
-          }
+          onClick={() => {
+            const config = buildConfig({
+              name: name.trim() || "Untitled Card",
+              elements,
+              theme,
+              shadow,
+              lighting,
+              animation,
+            });
+            onSave(config);
+          }}
         >
           Save
         </Button>
@@ -156,18 +166,17 @@ export function CardEditor({
           {showCode ? "Design View" : "Code View"}
         </Button>
         <Button
-          onClick={() =>
-            exportAssets(
-              buildConfig({
-                name,
-                elements,
-                theme,
-                shadow,
-                lighting,
-                animation,
-              }),
-            )
-          }
+          onClick={() => {
+            const config = buildConfig({
+              name: name.trim() || "Untitled Card",
+              elements,
+              theme,
+              shadow,
+              lighting,
+              animation,
+            });
+            exportAssets(config);
+          }}
           variant="secondary"
         >
           Export Assets

--- a/packages/card-builder/src/__tests__/delete-card.test.tsx
+++ b/packages/card-builder/src/__tests__/delete-card.test.tsx
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/components/ui/card', () => ({
+  Card: (props: any) => <div {...props} />,
+  CardHeader: (props: any) => <div {...props} />,
+  CardTitle: (props: any) => <div {...props} />,
+  CardDescription: (props: any) => <div {...props} />,
+  CardContent: (props: any) => <div {...props} />,
+}), { virtual: true });
+
+vi.mock('@/components/ui/button', () => ({
+  Button: (props: any) => <button {...props} />,
+}), { virtual: true });
+
+vi.mock('@/components/ui/input', () => ({
+  Input: (props: any) => <input {...props} />,
+}), { virtual: true });
+
+import { CardBuilderApp } from '../App';
+
+describe('packages/card-builder delete flow', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('removes card from state and localStorage', () => {
+    const initialCard = {
+      id: '1',
+      name: 'Sample',
+      elements: [],
+      theme: 'light',
+      shadow: 'none',
+      lighting: 'none',
+      animation: 'none',
+    };
+    localStorage.setItem('cards', JSON.stringify([initialCard]));
+
+    render(<CardBuilderApp />);
+
+    expect(screen.getAllByText('Sample')[0]).toBeTruthy();
+
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+    fireEvent.click(screen.getByText('Delete'));
+
+    expect(screen.queryByText('Sample')).toBeNull();
+    expect(localStorage.getItem('cards')).toBe(JSON.stringify([]));
+
+    confirmSpy.mockRestore();
+  });
+});

--- a/packages/card-builder/src/__tests__/rename.test.tsx
+++ b/packages/card-builder/src/__tests__/rename.test.tsx
@@ -16,6 +16,10 @@ vi.mock('@/components/ui/button', () => ({
   Button: (props: any) => <button {...props} />,
 }), { virtual: true });
 
+vi.mock('@/components/ui/input', () => ({
+  Input: (props: any) => <input {...props} />,
+}), { virtual: true });
+
 import { CardBuilderApp } from '../App';
 
 
@@ -41,7 +45,7 @@ describe('packages/card-builder rename flow', () => {
     render(<CardBuilderApp />);
 
     // ensure initial name rendered
-    expect(screen.getByText('Default Card')).toBeTruthy();
+    expect(screen.getAllByText('Default Card')[0]).toBeTruthy();
 
     // open editor
     fireEvent.click(screen.getByText('Edit'));
@@ -54,8 +58,8 @@ describe('packages/card-builder rename flow', () => {
     fireEvent.click(screen.getByText('Save'));
 
     // CardBuilderApp should display updated name
-    await screen.findByText('Renamed Card');
-    expect(screen.getByText('Renamed Card')).toBeTruthy();
+    await screen.findAllByText('Renamed Card');
+    expect(screen.getAllByText('Renamed Card')[0]).toBeTruthy();
 
     // saveCard should persist updated name to localStorage
     expect(setItemSpy).toHaveBeenLastCalledWith(


### PR DESCRIPTION
## Summary
- trim and default card titles via toolbar input, wiring save and export flows
- cover gallery deletion with a dedicated unit test
- extend Casey Rivera persona with latest work

## Testing
- `npx vitest run packages/card-builder/src/__tests__/rename.test.tsx packages/card-builder/src/__tests__/delete-card.test.tsx packages/card-builder/src/__tests__/config.test.ts packages/card-builder/src/__tests__/export-assets.test.ts --dir packages/card-builder`
- `npm test` *(fails: missing Playwright browsers; installation blocked by 403 "Domain forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68bb5bcd8ce88331b9c53936127ad112