### PR TITLE
feat(card-builder): export OpenAPI spec with card assets

### DIFF
--- a/packages/card-builder/Backend_Developer-Tariq_Al-Fulani.md
+++ b/packages/card-builder/Backend_Developer-Tariq_Al-Fulani.md
@@ -13,9 +13,10 @@ For the **Card Builder**, I’m designing the invisible scaffolding: the service
 - **[2025‑09‑07]** Began prototyping the API generator.  Explored both REST and GraphQL output formats and debated their merits with Casey and Riley.  Sketched out how functions imported from Code Explorer might map onto button actions.
 - **[2025‑09‑08]** Refactored the export flow to `exportAssets`, producing both the card's JSON blueprint and an OpenAPI 3 spec via a new `exportApi` module.
 - **[2025‑09‑09]** Hardened card loading by wrapping `localStorage` parsing in `try/catch`, logging corrupt data and offering an inline reset so designers can recover without reloads.
+- **[2025‑09‑10]** Finalised the `exportApi` module and wired the editor to `exportAssets`, so a single click now yields both `card.json` and a matching OpenAPI `card.yaml`.
 
 ## What I’m Doing
-Right now I’m polishing the API generator—tuning the OpenAPI output and sketching a plugin system so different runtime targets can extend it.  After adding resilient `localStorage` parsing and inline error reporting, my next focus is hardening validation and wiring serverless deployment hooks.
+With the export pipeline humming, I’m sketching a plugin system so different runtime targets can extend the generator.  Next up is hardening validation and wiring serverless deployment hooks.
 
 ## Where I’m Headed
 

--- a/packages/card-builder/src/__tests__/config.test.ts
+++ b/packages/card-builder/src/__tests__/config.test.ts
@@ -3,7 +3,7 @@
 // that the OpenAPI export contains expected metadata.
 import { describe, it, expect } from 'vitest';
 import { buildConfig, parseConfig } from '../Editor';
-import { generateOpenApi } from '../export';
+import { exportApi } from '../export';
 
 const base = {
   theme: 'light',
@@ -39,7 +39,7 @@ describe('card builder config', () => {
       ],
       ...base,
     });
-    const yaml = generateOpenApi(cfg);
+    const yaml = exportApi(cfg);
     expect(yaml).toContain('title: "My Card"');
     expect(yaml).toContain('/element/btn1');
     expect(yaml).toContain('openapi: "3.0.0"');

--- a/packages/card-builder/src/__tests__/export-assets.test.ts
+++ b/packages/card-builder/src/__tests__/export-assets.test.ts
@@ -1,12 +1,11 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi } from 'vitest';
 
-vi.mock('../export/openapi', () => ({
-  generateOpenApi: vi.fn(() => 'openapi: "3.0.0"'),
+vi.mock('../exportApi', () => ({
+  exportApi: vi.fn(() => 'openapi: "3.0.0"'),
 }));
 
-import { exportAssets, type CardConfig } from '../export';
-import { generateOpenApi } from '../export';
+import { exportAssets, exportApi, type CardConfig } from '../export';
 
 describe('exportAssets', () => {
   it('generates JSON and YAML downloads using card name', () => {
@@ -36,7 +35,7 @@ describe('exportAssets', () => {
     exportAssets(cfg);
 
     expect(createObjectURL).toHaveBeenCalledTimes(2);
-    expect(generateOpenApi).toHaveBeenCalledWith(cfg);
+    expect(exportApi).toHaveBeenCalledWith(cfg);
     expect(anchors[0].download).toBe('card.json');
     expect(anchors[1].download).toBe('card.yaml');
     expect(anchors[0].click).toHaveBeenCalled();

--- a/packages/card-builder/src/export/exportAssets.ts
+++ b/packages/card-builder/src/export/exportAssets.ts
@@ -1,5 +1,5 @@
-import { CardConfig } from "./types";
-import { generateOpenApi } from "./openapi";
+import type { CardConfig } from "./types";
+import { exportApi } from "../exportApi";
 
 export function exportAssets(config: CardConfig) {
   const data = JSON.stringify(config, null, 2);
@@ -11,7 +11,7 @@ export function exportAssets(config: CardConfig) {
   jsonLink.click();
   URL.revokeObjectURL(jsonUrl);
 
-  const yaml = generateOpenApi(config);
+  const yaml = exportApi(config);
   const yamlBlob = new Blob([yaml], { type: "application/yaml" });
   const yamlUrl = URL.createObjectURL(yamlBlob);
   const yamlLink = document.createElement("a");

--- a/packages/card-builder/src/export/index.ts
+++ b/packages/card-builder/src/export/index.ts
@@ -1,5 +1,5 @@
 export { buildConfig } from "./buildConfig";
 export { parseConfig } from "./parseConfig";
 export { exportAssets } from "./exportAssets";
-export { generateOpenApi } from "./openapi";
+export { exportApi } from "../exportApi";
 export type { CardConfig } from "./types";

--- a/packages/card-builder/src/exportApi.ts
+++ b/packages/card-builder/src/exportApi.ts
@@ -1,9 +1,9 @@
-import type { CardConfig } from "./types";
+import type { CardConfig } from "./export/types";
 
-// Convert a CardConfig into an OpenAPI 3.0 YAML document.
-// Each interactive element gets a minimal POST endpoint so consumers
-// can wire up server handlers for buttons and input fields.
-export function generateOpenApi(config: CardConfig): string {
+// Transform a CardConfig into an OpenAPI 3.0 YAML document.
+// Each interactive element maps to a minimal POST endpoint so
+// consumers can wire server handlers for buttons and inputs.
+export function exportApi(config: CardConfig): string {
   const paths: Record<string, any> = {};
 
   for (const el of config.elements) {
@@ -80,4 +80,5 @@ function toYaml(value: any, indent = 0): string {
   return String(value);
 }
 
-export default generateOpenApi;
+export default exportApi;
+


### PR DESCRIPTION
## Summary
- add `exportApi` to convert `CardConfig` into an OpenAPI 3 YAML document
- use `exportAssets` in the editor to download both `card.json` and `card.yaml`
- log progress in Tariq Al-Fulani's persona journal

## Testing
- `npm test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/webkit-2203/pw_run.sh)*

## Suggested tasks
- Tariq Al-Fulani: Read AGENT.md


------
https://chatgpt.com/codex/tasks/task_e_68bb5c95a73c83319f994d284721fd2b