### PR TITLE
feat: add card builder dev server

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "cross-env NODE_ENV=development tsx server/index.ts",
     "dev:explorer": "cross-env NODE_ENV=development tsx server/explorer.ts",
+    "dev:card": "cross-env NODE_ENV=development tsx server/card-builder.ts",
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist && tsx scripts/build-openapi.ts",
     "start": "cross-env NODE_ENV=production node dist/index.js",
     "check": "tsc",

--- a/packages/card-builder/DevOps_Engineer-Bianca_Rossi.md
+++ b/packages/card-builder/DevOps_Engineer-Bianca_Rossi.md
@@ -11,13 +11,15 @@ For **Card Builder**, my job is to make sure that contributors can develop, test
 - **[2025‑09‑05]** Joined Card Builder to create a robust development environment.  Set up a separate `npm run dev:card-builder` script and a dev server running at `localhost:3100`.  Documented how to run the editor in isolation.
 - **[2025‑09‑06]** Containerised the editor and backend services using Docker Compose.  Added hot reload support so code changes update live.  Helped Casey and Tariq get their local setups working smoothly.
 - **[2025‑09‑07]** Wrote GitHub Actions workflows to run tests on pull requests and to build/export cards on tagged releases.  Introduced caching layers to speed up repeated builds.  Compared the satisfaction to making a perfect lasagne.
+- **[2025‑09‑16]** Wired up a standalone dev server that mounts the Card Builder package with `setupViteFor`. Added a `dev:card` npm script that opens the editor at `localhost:PORT/card-builder` so anyone can preview cards without touching the main app.
 
 ## What I’m Doing
 
-I’m currently building the packaging pipeline that turns a designed card into a distributable artefact.  This includes bundling the React code, generating the API spec, versioning the package and publishing it to our private registry.  I’m also exploring ways to support exporting cards as Web Components and NPM packages, so they can integrate into any frontend stack.  Parallel to this, I’m drafting onboarding documentation that reads like a recipe book: clear steps, tips and notes on serving suggestions.  Finally, I’m investigating how to use Tauri to wrap the Card Builder as a desktop app for offline usage.
+Fresh off the new dev server, I’m refining the packaging pipeline that turns a designed card into a distributable artefact.  This includes bundling the React code, generating the API spec, versioning the package and publishing it to our private registry.  I’m also exploring ways to support exporting cards as Web Components and NPM packages, so they can integrate into any frontend stack.  Parallel to this, I’m drafting onboarding documentation that reads like a recipe book: clear steps, tips and notes on serving suggestions.  Finally, I’m investigating how to use Tauri to wrap the Card Builder as a desktop app for offline usage.
 
 ## Where I’m Headed
 
 - Automate the creation of preview environments for each pull request so designers and stakeholders can click a link and try a new feature before it’s merged.  It’s like offering a tasting menu before committing to the full course.
 - Integrate environment variables and secrets management so generated APIs can connect to real backends securely without leaking credentials.
 - Write a postmortem template for incidents (should they occur) that emphasises learning and continuous improvement.  In cooking and devops alike, mistakes are opportunities to refine the recipe.
+- Package the dev server into a reusable Docker image so new contributors can taste-test the editor with a single command.

--- a/server/card-builder.ts
+++ b/server/card-builder.ts
@@ -1,0 +1,20 @@
+import express from "express";
+import { createServer } from "http";
+import path from "path";
+import open from "open";
+import { setupViteFor, log } from "./vite";
+
+const app = express();
+
+const server = createServer(app);
+
+(async () => {
+  const rootDir = path.resolve(import.meta.dirname, "..", "packages", "card-builder");
+  await setupViteFor(app, server, rootDir, "/card-builder");
+
+  const port = parseInt(process.env.PORT || "5000", 10);
+  server.listen({ port, host: "0.0.0.0", reusePort: true }, () => {
+    log(`card builder dev server running on port ${port}`);
+    void open(`http://localhost:${port}/card-builder`, { wait: false }).catch(() => {});
+  });
+})();


### PR DESCRIPTION
## Summary
- expose Card Builder through a dedicated dev server mounted with `setupViteFor`
- add `dev:card` script for quick access to Card Builder editor
- log deployment steps in Bianca Rossi's journal

## Testing
- `npm test` *(fails: browserType.launch: Executable doesn't exist)*
- `npx playwright install` *(fails: Download failed: server returned code 403 body 'Domain forbidden')*
- `npm run test:playwright` *(fails: browserType.launch: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68bb5f60341c833181422eed87e66bca