### PR TITLE
feat: extend function parser with async and tag filtering

### DIFF
--- a/packages/code-explorer/Tech_Lead-Jordan_Rowe.md
+++ b/packages/code-explorer/Tech_Lead-Jordan_Rowe.md
@@ -70,7 +70,7 @@ Coordinating integration of code exploration features while aligning documentati
 
 
 ## 🔄 Status
-- **Past:** Finalized initial AST index design and integrated CodeMirror editors.
-- **Current:** Implemented an AST-driven parser and surfacing results via `/code-explorer/api/functions` with expanded tests.
+- **Past:** Delivered an initial AST parser and `/code-explorer/api/functions` endpoint.
+- **Current:** Added async/arrow function support with tag filtering and exercised the API through unit tests.
 - **Future:** Investigate incremental parsing and broaden coverage for class methods and default exports.
 

--- a/packages/code-explorer/__tests__/functions.test.ts
+++ b/packages/code-explorer/__tests__/functions.test.ts
@@ -24,13 +24,13 @@ afterAll(() => {
   fs.rmSync(repoDir, { recursive: true, force: true });
 });
 
-describe("GET /functions", () => {
+describe("GET /code-explorer/api/functions", () => {
   it("returns function metadata", async () => {
     const app = express();
-    app.use("/functions", createFunctionsRouter(() => repoDir));
+    app.use("/code-explorer/api/functions", createFunctionsRouter(() => repoDir));
     const server = app.listen(0);
     const { port } = server.address() as any;
-    const res = await fetch(`http://localhost:${port}/functions`);
+    const res = await fetch(`http://localhost:${port}/code-explorer/api/functions`);
     const data = await res.json();
     server.close();
     expect(res.status).toBe(200);
@@ -40,12 +40,26 @@ describe("GET /functions", () => {
     ]);
   });
 
-  it("returns 400 when repository is not loaded", async () => {
+  it("filters by tag", async () => {
     const app = express();
-    app.use("/functions", createFunctionsRouter(() => null));
+    app.use("/code-explorer/api/functions", createFunctionsRouter(() => repoDir));
     const server = app.listen(0);
     const { port } = server.address() as any;
-    const res = await fetch(`http://localhost:${port}/functions`);
+    const res = await fetch(`http://localhost:${port}/code-explorer/api/functions?tag=util`);
+    const data = await res.json();
+    server.close();
+    expect(res.status).toBe(200);
+    expect(data).toEqual([
+      { name: "hi", signature: "hi(): any", path: "a.ts", tags: ["util"] },
+    ]);
+  });
+
+  it("returns 400 when repository is not loaded", async () => {
+    const app = express();
+    app.use("/code-explorer/api/functions", createFunctionsRouter(() => null));
+    const server = app.listen(0);
+    const { port } = server.address() as any;
+    const res = await fetch(`http://localhost:${port}/code-explorer/api/functions`);
     server.close();
     expect(res.status).toBe(400);
   });
@@ -53,10 +67,10 @@ describe("GET /functions", () => {
   it("returns 500 when scan fails", async () => {
     const app = express();
     // provide non-existent directory to trigger scan error
-    app.use("/functions", createFunctionsRouter(() => "/no/such/dir"));
+    app.use("/code-explorer/api/functions", createFunctionsRouter(() => "/no/such/dir"));
     const server = app.listen(0);
     const { port } = server.address() as any;
-    const res = await fetch(`http://localhost:${port}/functions`);
+    const res = await fetch(`http://localhost:${port}/code-explorer/api/functions`);
     server.close();
     expect(res.status).toBe(500);
   });

--- a/packages/code-explorer/__tests__/scan.test.ts
+++ b/packages/code-explorer/__tests__/scan.test.ts
@@ -14,6 +14,7 @@ beforeAll(() => {
       "/** @tag util */",
       "function decl(a: number, b: number): number { return a + b; }",
       "const arrow = (x: string) => x;",
+      "const asyncArrow = async () => {};",
       "export default function () {}",
     ].join("\n"),
   );
@@ -38,6 +39,24 @@ describe("scan", () => {
         signature: "arrow(x: string): any",
         path: "sample.ts",
         tags: [],
+      },
+      {
+        name: "asyncArrow",
+        signature: "async asyncArrow(): any",
+        path: "sample.ts",
+        tags: [],
+      },
+    ]);
+  });
+
+  it("filters by tag", () => {
+    const result = scan(dir, { tag: "util" });
+    expect(result).toEqual([
+      {
+        name: "decl",
+        signature: "decl(a: number, b: number): number",
+        path: "sample.ts",
+        tags: ["util"],
       },
     ]);
   });

--- a/server/functions.ts
+++ b/server/functions.ts
@@ -20,7 +20,8 @@ export function createFunctionsRouter(getRepoDir: () => string | null) {
       return res.status(400).json({ error: "Repository not loaded" });
     }
     try {
-      const data = scan(dir);
+      const tag = typeof req.query.tag === "string" ? req.query.tag : undefined;
+      const data = scan(dir, tag ? { tag } : {});
       res.json(data);
     } catch (err: any) {
       res.status(500).json({ error: err.message });


### PR DESCRIPTION
## Summary
- capture async functions and allow tag-based filtering in scan
- add tag query support to `/code-explorer/api/functions`
- document tech lead status update

## Testing
- `npm run pre-commit`
- `npx vitest run --root packages/code-explorer` *(fails: Objects are not valid as a React child)*
- `npx vitest run --root packages/code-explorer __tests__/scan.test.ts __tests__/functions.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68bb60baac488331b8ed33ef5ade3dca