### PR TITLE
feat(card-builder): trim card names and tidy storage

### DIFF
--- a/packages/card-builder/Frontend_Developer-Casey_Rivera.md
+++ b/packages/card-builder/Frontend_Developer-Casey_Rivera.md
@@ -17,6 +17,8 @@ I adore crafting interactions that feel tactile and alive.  Animations, responsi
 
 - **[2025-09-11]** Polished the editor toolbar with a proper name input that trims stray spaces and falls back to "Untitled Card".  Wrote a safety net test to ensure gallery deletions wipe cards from localStorage as cleanly as a fresh coat of paint.
 
+- **[2025-09-12]** Tidied the gallery by trimming card titles on save and teaching the delete button to clear localStorage when a card vanishes.
+
 ## What I’m Doing
 
 With the toolbar’s naming field polished and deletion covered, I’m circling back to refining the properties panel to be more intuitive.  I’m adding colour wheels, font selectors and dynamic controls that show only relevant fields for each element.  I’m also working on keyboard accessibility, ensuring that every drag‑and‑drop action can be replicated with a keyboard alone.  In tandem, I’m experimenting with generative themes where the card’s palette adapts to the user’s selected primary colour, creating harmonious shades automatically.  All while listening to salsa beats in the background, of course.

--- a/packages/card-builder/src/App.tsx
+++ b/packages/card-builder/src/App.tsx
@@ -107,6 +107,14 @@ export function CardBuilderApp() {
   const [error, setError] = useState<string | null>(initialError);
   const [editing, setEditing] = useState<StoredCard | null>(null);
 
+  const persistCards = (list: StoredCard[]) => {
+    if (list.length) {
+      localStorage.setItem("cards", JSON.stringify(list));
+    } else {
+      localStorage.removeItem("cards");
+    }
+  };
+
   const resetStorage = () => {
     localStorage.removeItem("cards");
     setCards([]);
@@ -117,7 +125,7 @@ export function CardBuilderApp() {
     if (!window.confirm("Delete this card?")) return;
     setCards((prev) => {
       const list = prev.filter((c) => c.id !== id);
-      localStorage.setItem("cards", JSON.stringify(list));
+      persistCards(list);
       return list;
     });
   };
@@ -129,7 +137,7 @@ export function CardBuilderApp() {
       const list = prev.some((c) => c.id === updated.id)
         ? prev.map((c) => (c.id === updated.id ? updated : c))
         : [...prev, updated];
-      localStorage.setItem("cards", JSON.stringify(list));
+      persistCards(list);
       return list;
     });
     setEditing(null);

--- a/packages/card-builder/src/Editor.tsx
+++ b/packages/card-builder/src/Editor.tsx
@@ -74,6 +74,20 @@ export function CardEditor({
     );
   }, [name, elements, theme, shadow, lighting, animation]);
 
+  const handleSave = () => {
+    const resolvedName = name.trim() || "Untitled Card";
+    setName(resolvedName);
+    const config = buildConfig({
+      name: resolvedName,
+      elements,
+      theme,
+      shadow,
+      lighting,
+      animation,
+    });
+    onSave(config);
+  };
+
   const applyCode = () => {
     const parsed = parseConfig(code);
     if (!parsed) {
@@ -147,19 +161,7 @@ export function CardEditor({
         </select>
 
         <Button onClick={onBack} variant="outline">Back</Button>
-        <Button
-          onClick={() => {
-            const config = buildConfig({
-              name: name.trim() || "Untitled Card",
-              elements,
-              theme,
-              shadow,
-              lighting,
-              animation,
-            });
-            onSave(config);
-          }}
-        >
+        <Button onClick={handleSave}>
           Save
         </Button>
         <Button onClick={() => setShowCode((v) => !v)} className="ml-auto">


### PR DESCRIPTION
## Summary
- ensure editor trims card names before saving and passes resolved name to `onSave`
- centralize card persistence logic and remove localStorage data when no cards remain
- log Casey Rivera's tidy gallery update

## Testing
- `npm run pre-commit`
- `npm test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/webkit-2203/pw_run.sh)*

------
https://chatgpt.com/codex/tasks/task_e_68bb619fa0888331b06be7283fabe626