### PR TITLE
docs: expand function index and browser workflow

### DIFF
--- a/packages/code-explorer/Documentation_Ops-Alex_Kim.md
+++ b/packages/code-explorer/Documentation_Ops-Alex_Kim.md
@@ -23,7 +23,7 @@ Standardize repository documentation and automate release notes.
 ## 📝 Current Task Notes
 - Published Code Explorer runbook covering tests, save/patch flow, and viewer fallback.
 - Tracking automated release-note tooling; next step is wiring changelog script into CI.
-- Expanded runbook and onboarding docs with the function-index API and the new FunctionBrowser drag-and-drop flow.
+- Refreshed runbook and onboarding docs with sample function-index responses and step-by-step FunctionBrowser drag-and-drop flow.
 
 ## 🗂️ Project Notes
 - Reference documentation kept in `/docs`; update as features stabilize.

--- a/packages/code-explorer/docs/onboarding.md
+++ b/packages/code-explorer/docs/onboarding.md
@@ -17,9 +17,16 @@
 - Update your profile whenever your assignment or availability changes and at least once per sprint.
 
 ## Function Index & UI Flow
-- The **function-index API** (`/api/functions`) provides scanned function metadata such as name, signature, path, and tags.
-- The `FunctionBrowser` panel fetches this data and supports search, filtering, and drag-and-drop.
-- Drag functions from the browser onto the `CompositionCanvas` to create nodes and wire them together.
+- `GET /api/functions` returns an array of scanned function metadata.
+  ```json
+  [
+    { "name": "add", "path": "src/math.ts", "line": 12, "tags": ["math"] }
+  ]
+  ```
+- The `FunctionBrowser` panel fetches this list and supports search, filtering, and drag-and-drop.
+  1. Open the browser and search or filter by tag.
+  2. Drag a function onto the `CompositionCanvas` to create a node.
+  3. Connect nodes to build flows.
 
 ## Testing Commands
 - Run all repository tests:

--- a/packages/code-explorer/docs/runbook.md
+++ b/packages/code-explorer/docs/runbook.md
@@ -26,9 +26,16 @@
 - When a language definition is missing or Prism throws, `highlightCode` returns the original string so the viewer renders plain text instead of crashing.
 
 ## Function Index & UI Flow
-- The **function-index API** at `GET /api/functions` returns metadata for each repository function, generated from `server/function-index.ts`.
+- The **function-index API** at `GET /api/functions` returns metadata for each repository function. The index is generated at startup by `server/function-index.ts`.
+- Response shape:
+  ```json
+  [
+    { "name": "add", "path": "src/math.ts", "line": 12, "tags": ["math"] }
+  ]
+  ```
 - The `FunctionBrowser` panel consumes this endpoint and lets users search or filter for functions.
-- Drag a function from the browser onto the `CompositionCanvas` to create a node and start composing flows.
+  - Open the browser, search or filter by tag, and drag a function onto the `CompositionCanvas`.
+  - Dropping the function creates a node and begins a new flow.
 
 ## Release Notes Automation
 - Changelog generation script: `node packages/code-explorer/scripts/generate-changelog.js CHANGELOG.md`.


### PR DESCRIPTION
## Summary
- expand runbook with function-index API response and FunctionBrowser usage steps
- update onboarding with sample function-index data and drag-and-drop instructions
- note documentation refresh in Alex Kim's log

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb66cc7dc0833195c89596f89449f8