### PR TITLE
docs: clarify card export downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mining Syndicate Platform
 
-See [Onboarding Guide](docs/onboarding.md) for setup, tests, and profile conventions. Consult [Exporting Cards](docs/exporting-cards.md) to turn Card Builder creations into reusable modules, and follow our [Documentation Style Guide](docs/style-guide.md). Install CodeMirror and its language packages with `npm install` so code snippets can be highlighted.
+See [Onboarding Guide](docs/onboarding.md) for setup, tests, and profile conventions. Consult [Exporting Cards](docs/exporting-cards.md) to download card modules with JSON or OpenAPI specs, and follow our [Documentation Style Guide](docs/style-guide.md). Install CodeMirror and its language packages with `npm install` so code snippets can be highlighted.
 
 ## Development
 

--- a/docs/exporting-cards.md
+++ b/docs/exporting-cards.md
@@ -11,10 +11,11 @@ Turn a Card Builder creation into a reusable module that ships with its own API 
 
 ## Export
 1. Click **Export** in the toolbar.
-2. Choose your preferred format (React component or Web Component).
-3. Download the bundle. It includes:
-   - the component source;
-   - an OpenAPI spec describing generated endpoints.
+2. Choose a component format: React or Web Component.
+3. Pick your downloads:
+   - **card.json** captures the card configuration.
+   - **openapi.yaml** lists the generated endpoints.
+4. Save the files to your project.
 
 ## Next steps
 - Import the component into your application.

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -10,6 +10,7 @@ Consistency keeps our guides accessible and easy to maintain. Follow these conve
 - Start each page with an H1 title.
 - Use sentence case for headings.
 - Wrap commands and code samples in fenced blocks.
+- Mention file formats in uppercase (`JSON`, `OpenAPI`).
 
 ## Cross-links
-- Connect related topics. For export instructions, see [Exporting Cards](./exporting-cards.md).
+- Connect related topics. For export steps and JSON/OpenAPI downloads, see [Exporting Cards](./exporting-cards.md).

--- a/packages/card-builder/Technical_Writer-Morgan_Lee.md
+++ b/packages/card-builder/Technical_Writer-Morgan_Lee.md
@@ -12,9 +12,11 @@ Card Builder drew me in because every exported card is both prop and protagonist
 
 - **[2025-09-15]** Polished the exporting cards tutorial, refreshed the style guide, and linked both from the README for easy discovery.
 
+- **[2025-09-18]** Published the exporting guide with JSON and OpenAPI downloads and refreshed the style guide with cross-links.
+
 ## What I’m Doing
 
-I'm inviting the crew to review the new exporting tutorial and style guide, taking notes for the next revision.
+I'm gathering real-world examples of JSON and OpenAPI exports to guide the next revision.
 
 ## Where I’m Headed
 


### PR DESCRIPTION
## Summary
- explain how to download card.json and openapi.yaml when exporting cards
- note JSON and OpenAPI terminology in the docs style guide
- mention JSON/OpenAPI specs in README and Morgan Lee profile

## Testing
- `npm test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/webkit-2203/pw_run.sh)*

------
https://chatgpt.com/codex/tasks/task_e_68bb67f34e1c83319ad0f446d8557735