### PR TITLE
docs: refine code explorer roadmap and process

### DIFF
--- a/packages/code-explorer/AGENT.md
+++ b/packages/code-explorer/AGENT.md
@@ -1,0 +1,6 @@
+# Code Explorer Process Guide
+
+- Keep role files updated with Past/Current/Future logs each sprint.
+- Before committing, run `npm test` and `npm run check`.
+- Install Playwright browsers before running end-to-end tests (`npx playwright install`).
+- Sync backend, frontend, QA, and docs progress in weekly check-ins, and refine the roadmap accordingly.

--- a/packages/code-explorer/Product_Manager-Ava_Wu.md
+++ b/packages/code-explorer/Product_Manager-Ava_Wu.md
@@ -43,11 +43,14 @@ Preparing the code explorer package for beta launch and refining remaining featu
 - Launched discovery for the card-builder initiative and defined MVP milestones.
 - Ran design sprint and user interviews to validate card creation workflows.
 - Assigned work for the function library and canvas integration to move Code Explorer toward beta.
+- Backend delivered async/arrow function support and Function Browser entered drag-and-drop testing; QA expanded regression coverage and docs published updated runbook.
 ### Current
 - Driving cross-team development of card-builder and aligning integration with code explorer.
 - Prioritizing backlog for card-builder beta and tracking package dependencies.
 - Coordinating function indexing API, UI wiring, and test coverage across teams.
+- Aligning incremental parsing research, release-note automation, and beta timeline for Code Explorer.
 ### Future
 - Planning rollout strategy and metrics for card-builder adoption.
 - Mapping long-term roadmap for advanced card templates and collaborative editing.
 - Extending vision to multi-file patching and automated dependency conflict alerts.
+- Benchmark incremental AST parsing, wire changelog tooling into CI, and broaden test coverage for class methods and default exports.


### PR DESCRIPTION
## Summary
- update Ava Wu's product management log with cross-team progress and next steps
- add Code Explorer process guide outlining testing and sync expectations

## Testing
- `npm test`
- `npm run check` *(fails: missing types and schema references)*

------
https://chatgpt.com/codex/tasks/task_e_68bb67f43c8883318b2063c2c1f318f8