### PR TITLE
feat(card-builder): add operation ids to openapi export

### DIFF
--- a/packages/card-builder/Backend_Developer-Tariq_Al-Fulani.md
+++ b/packages/card-builder/Backend_Developer-Tariq_Al-Fulani.md
@@ -15,6 +15,7 @@ For the **Card Builder**, I’m designing the invisible scaffolding: the service
 - **[2025‑09‑09]** Hardened card loading by wrapping `localStorage` parsing in `try/catch`, logging corrupt data and offering an inline reset so designers can recover without reloads.
 - **[2025‑09‑10]** Finalised the `exportApi` module and wired the editor to `exportAssets`, so a single click now yields both `card.json` and a matching OpenAPI `card.yaml`.
 - **[2025‑09‑11]** Re-read the team `AGENT.md` to stay in sync and confirmed the export pipeline and storage safeguards are working as designed.
+- **[2025‑09‑12]** Added explicit operation IDs to the OpenAPI generator so downstream services can hook into each element's endpoint by name. Verified storage error handling stays inline and friendly.
 
 ## What I’m Doing
 With the export pipeline humming, I’m sketching a plugin system so different runtime targets can extend the generator.  Next up is hardening validation and wiring serverless deployment hooks.

--- a/packages/card-builder/src/exportApi.ts
+++ b/packages/card-builder/src/exportApi.ts
@@ -12,6 +12,7 @@ export function exportApi(config: CardConfig): string {
 
     if (el.elementId === "button") {
       operations.post = {
+        operationId: `handle_${el.id}`,
         summary: `Handle ${el.props.label || "button"} click`,
         responses: {
           "200": { description: "Success" },
@@ -19,6 +20,7 @@ export function exportApi(config: CardConfig): string {
       };
     } else if (el.displayMode === "input") {
       operations.post = {
+        operationId: `submit_${el.id}`,
         summary: `Submit value for ${el.props.label || "input"}`,
         requestBody: {
           required: true,


### PR DESCRIPTION
## Summary
- assign unique operation IDs when exporting card configs to OpenAPI
- log backend work on refining OpenAPI and storage error handling

## Testing
- `npm test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/webkit-2203/pw_run.sh)*

------
https://chatgpt.com/codex/tasks/task_e_68bb6c29133883319a8cfc850ab3a0ba