### PR TITLE
test: enhance FunctionBrowser coverage

### DIFF
--- a/packages/code-explorer/Frontend_Developer-Simon_Hesher.md
+++ b/packages/code-explorer/Frontend_Developer-Simon_Hesher.md
@@ -40,6 +40,8 @@ drag-and-drop libraries, and dependency graph automation.
   endpoint and verify selection callbacks during drag events.
 - Added case-insensitive filtering and canvas integration tests covering
   function selection and drop events.
+- Extended Function Browser tests for filter clearing, multiple selection
+  callbacks, and verifying node coordinates on canvas drops.
 
 ## 🔮 Future Designs
 - Cross-fade transitions when switching between the Function Browser, Canvas, and Code Pane.

--- a/packages/code-explorer/src/components/CompositionCanvas.tsx
+++ b/packages/code-explorer/src/components/CompositionCanvas.tsx
@@ -37,8 +37,10 @@ export function CompositionCanvas({ nodes, connections, onUpdate }: Props) {
     const fn = e.dataTransfer.getData("text/plain");
     if (!fn) return;
     const rect = e.currentTarget.getBoundingClientRect();
-    const x = e.clientX - rect.left;
-    const y = e.clientY - rect.top;
+    const clientX = typeof e.clientX === "number" ? e.clientX : 0;
+    const clientY = typeof e.clientY === "number" ? e.clientY : 0;
+    const x = clientX - rect.left;
+    const y = clientY - rect.top;
     const node: CompositionNode = { id: nanoid(), name: fn, x, y };
     const updated = { nodes: [...localNodes, node], connections: localConnections };
     setLocalNodes(updated.nodes);


### PR DESCRIPTION
## Summary
- handle missing drop coordinates when composing functions on the canvas
- broaden FunctionBrowser tests for filtering, selection, and drop positioning
- log sprint progress for Function Browser improvements

## Testing
- `npx playwright install` *(fails: Domain forbidden)*
- `npm test`
- `npx vitest run src/components/FunctionBrowser.test.tsx -t "places nodes at drop coordinates"`
- `npm run check` *(fails: TS2304, TS18046, TS2345, TS2551, TS2339, TS2769, TS2322)*

------
https://chatgpt.com/codex/tasks/task_e_68bb6d2330688331b991a814f84736b5