### PR TITLE
docs: add naming/export/delete wireframes and notes

### DIFF
--- a/docs/design/naming-export-delete.md
+++ b/docs/design/naming-export-delete.md
@@ -1,31 +1,32 @@
 # Toolbar Naming, Export, and Gallery Delete Wireframes
 
-These sketches map the latest flow for naming cards, exporting them, and managing deletions in the gallery.
+These sketches map the flow for naming cards, exporting them, and deleting saved cards in the gallery.
 
-## Toolbar: name field & export button
+## Toolbar: Name field & Export button
 ```
-+------------------------------------------------------------------+
-| [card name____________________]                [ Export ]        |
-+------------------------------------------------------------------+
++--------------------------------------------------------------------+
+| Name: [ Untitled Card________ ]                        [ Export ]  |
++--------------------------------------------------------------------+
 ```
-- Name field auto-trims spaces and defaults to **Untitled Card**.
+- Name field auto-trims spaces and falls back to **Untitled Card**.
 - Export button opens a modal confirming assets and API bundle.
+- Export button is disabled until a non-empty name is provided.
 
 ## Gallery: delete affordance
 ```
-+------------------------------+
-| [thumbnail]  Card Title      |
-|              [🗑 Delete]     |
-+------------------------------+
++----------------------------------------------+
+| [thumbnail]  Card Title                [🗑]   |
++----------------------------------------------+
 ```
-- Trash icon reveals a confirm dialog before removal.
-- Successful deletion animates the card fading out.
+- Trash icon appears on hover; clicking prompts a confirm dialog before removal.
+- Successful deletion fades the card out and cleans up localStorage.
 
 ## Interaction Notes
 
 ### Casey Rivera
 - Casey Rivera: Read AGENT.md
 - Casey Rivera: Ensure keyboard focus order flows from name field to export button.
+- Casey Rivera: Style disabled Export state when name field is empty.
 - Casey Rivera: Wire delete animation and confirmation dialog in the gallery.
 
 ### Tariq Al-Fulani

--- a/packages/card-builder/UI_Designer-Jade_Nguyen.md
+++ b/packages/card-builder/UI_Designer-Jade_Nguyen.md
@@ -13,11 +13,11 @@ At the **Card Builder**, my mission is to make the editor feel like a studio whe
 - **[2025‑09‑07]** Collaborated with Casey to implement the first version of the theme switcher.  We tested neon, retro and solarised palettes.  Documented guidelines in the Figma library and started a mood board for future inspirations.
 - **[2025-09-08]** Sketched wireframes for the toolbar’s name field and export button, captured interaction notes for the team.
 - **[2025-09-13]** Finalised toolbar naming and export sketches and added a gallery delete wireframe in `docs/design/naming-export-delete.md`, leaving notes for Casey and Tariq.
+- **[2025-09-14]** Refined those wireframes with disabled Export states and backend sync details. Shared the updated interaction notes with Casey and Tariq.
 
 ## What I’m Doing
 
-With the wireframes captured, I'm shaping a clickable prototype for naming, export and gallery deletion.
-I’m pairing with Casey to finesse responsive layout and looping in Tariq to validate export payloads.
+With the wireframes iterated, I'm shaping a clickable prototype for naming, export and gallery deletion. I'm pairing with Casey to finesse responsive layout and looping in Tariq to validate export payloads while we test the new notes.
 
 ## Where I’m Headed
 


### PR DESCRIPTION
## Summary
- Refine toolbar naming, export, and gallery delete wireframes and leave targeted notes for Casey and Tariq
- Extend Jade Nguyen's persona with new wireframe notes and current work focus

## Testing
- `npm test` *(fails: page._wrapApiCall: Test timeout of 30000ms exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_68bb6d23f3f083319c0baef8d41743a7