### PR TITLE
docs: add function index and browser flow

### DIFF
--- a/packages/code-explorer/Documentation_Ops-Alex_Kim.md
+++ b/packages/code-explorer/Documentation_Ops-Alex_Kim.md
@@ -23,7 +23,7 @@ Standardize repository documentation and automate release notes.
 ## 📝 Current Task Notes
 - Published Code Explorer runbook covering tests, save/patch flow, and viewer fallback.
 - Tracking automated release-note tooling; next step is wiring changelog script into CI.
-- Refreshed runbook and onboarding docs with sample function-index responses and step-by-step FunctionBrowser drag-and-drop flow.
+- Documented function-index API and detailed FunctionBrowser flow in runbook and onboarding guides.
 
 ## 🗂️ Project Notes
 - Reference documentation kept in `/docs`; update as features stabilize.

--- a/packages/code-explorer/docs/onboarding.md
+++ b/packages/code-explorer/docs/onboarding.md
@@ -16,14 +16,14 @@
 - Profiles include sections for Introduction, Biography, Core Skills & Tools, Contact & Availability, Current Assignment, Current Task Notes, Project Notes, and Urgent Notes (leave empty when nothing is pressing).
 - Update your profile whenever your assignment or availability changes and at least once per sprint.
 
-## Function Index & UI Flow
-- `GET /api/functions` returns an array of scanned function metadata.
+## Function Index & `FunctionBrowser` Flow
+- `GET /api/functions` returns the prebuilt function index generated at startup by `server/function-index.ts`.
   ```json
   [
     { "name": "add", "path": "src/math.ts", "line": 12, "tags": ["math"] }
   ]
   ```
-- The `FunctionBrowser` panel fetches this list and supports search, filtering, and drag-and-drop.
+- The `FunctionBrowser` panel fetches this list and supports search, filtering, and drag-and-drop:
   1. Open the browser and search or filter by tag.
   2. Drag a function onto the `CompositionCanvas` to create a node.
   3. Connect nodes to build flows.

--- a/packages/code-explorer/docs/runbook.md
+++ b/packages/code-explorer/docs/runbook.md
@@ -25,17 +25,18 @@
 - Code highlighting uses Prism grammars.
 - When a language definition is missing or Prism throws, `highlightCode` returns the original string so the viewer renders plain text instead of crashing.
 
-## Function Index & UI Flow
-- The **function-index API** at `GET /api/functions` returns metadata for each repository function. The index is generated at startup by `server/function-index.ts`.
-- Response shape:
+## Function Index & `FunctionBrowser` Flow
+- `GET /api/functions` exposes the prebuilt **function index** generated at startup by `server/function-index.ts`. Each entry includes a function's name, path, line number, and optional tags.
+- Sample response:
   ```json
   [
     { "name": "add", "path": "src/math.ts", "line": 12, "tags": ["math"] }
   ]
   ```
-- The `FunctionBrowser` panel consumes this endpoint and lets users search or filter for functions.
-  - Open the browser, search or filter by tag, and drag a function onto the `CompositionCanvas`.
-  - Dropping the function creates a node and begins a new flow.
+- The **FunctionBrowser** panel queries this endpoint and supports search, filtering, and drag-and-drop:
+  1. Open the browser from the explorer sidebar.
+  2. Search or filter by tag to locate a function.
+  3. Drag the function onto the `CompositionCanvas` to create a node and start a new flow.
 
 ## Release Notes Automation
 - Changelog generation script: `node packages/code-explorer/scripts/generate-changelog.js CHANGELOG.md`.


### PR DESCRIPTION
## Summary
- detail function-index API and FunctionBrowser drag-and-drop steps in runbook and onboarding guides
- log function-index documentation work in Alex Kim's notes

## Testing
- `npx playwright install` *(fails: Download failed: server returned code 403)*
- `npm test`
- `npm run check` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bb6ebb20a883319ffd4945e243f764