### PR TITLE
feat: extend function endpoint tests

### DIFF
--- a/packages/code-explorer/Tech_Lead-Jordan_Rowe.md
+++ b/packages/code-explorer/Tech_Lead-Jordan_Rowe.md
@@ -70,7 +70,7 @@ Coordinating integration of code exploration features while aligning documentati
 
 
 ## 🔄 Status
-- **Past:** Added async and arrow function support with tag filtering and exercised the API through unit tests.
-- **Current:** Extended the AST parser with generator detection and verified `/code-explorer/api/functions` through new unit tests.
+- **Past:** Converted `scan.js` utilities into the `/code-explorer/api/functions` endpoint indexing declared, arrow, and async functions with tag filtering.
+- **Current:** Expanding unit tests to cover typical and edge cases for the functions endpoint.
 - **Future:** Investigate incremental parsing and broaden coverage for class methods and default exports.
 

--- a/packages/code-explorer/__tests__/functions.test.ts
+++ b/packages/code-explorer/__tests__/functions.test.ts
@@ -16,6 +16,10 @@ beforeAll(() => {
       "function hi(){}",
       "/** @tag edge */",
       "const bye = () => {}",
+      "/** @tag async */",
+      "async function asyncDecl(){}",
+      "/** @tag async */",
+      "const asyncArrow = async () => {}",
       "/** @tag gen */",
       "function* gen(){}",
     ].join("\n"),
@@ -39,6 +43,8 @@ describe("GET /code-explorer/api/functions", () => {
     expect(data).toEqual([
       { name: "hi", signature: "hi(): any", path: "a.ts", tags: ["util"] },
       { name: "bye", signature: "bye(): any", path: "a.ts", tags: ["edge"] },
+      { name: "asyncDecl", signature: "async asyncDecl(): any", path: "a.ts", tags: ["async"] },
+      { name: "asyncArrow", signature: "async asyncArrow(): any", path: "a.ts", tags: ["async"] },
       { name: "gen", signature: "*gen(): any", path: "a.ts", tags: ["gen"] },
     ]);
   });


### PR DESCRIPTION
## Summary
- broaden API tests to index async declarations and arrow functions
- log sprint status updates for Tech Lead

## Testing
- `npm test`
- `npx vitest run packages/code-explorer/__tests__/functions.test.ts`
- `npm run check` *(fails: missing modules and typing errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bb72631bc8833191ab53ffbfb98928