### PR TITLE
docs: clarify card exporting and style guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # Mining Syndicate Platform
 
-See [Onboarding Guide](docs/onboarding.md) for setup, tests, and profile conventions. Consult [Exporting Cards](docs/exporting-cards.md) to download card modules with JSON or OpenAPI specs, and follow our [Documentation Style Guide](docs/style-guide.md). Install CodeMirror and its language packages with `npm install` so code snippets can be highlighted.
+See our key guides:
+
+- [Onboarding Guide](docs/onboarding.md) for setup, tests, and profile conventions.
+- [Exporting Cards](docs/exporting-cards.md) to download card modules with `JSON` or `OpenAPI` specs.
+- [Documentation Style Guide](docs/style-guide.md) for writing tone and formatting.
+
+Install CodeMirror and its language packages with `npm install` so code snippets can be highlighted.
 
 ## Development
 

--- a/docs/exporting-cards.md
+++ b/docs/exporting-cards.md
@@ -11,10 +11,12 @@ Turn a Card Builder creation into a reusable module that ships with its own API 
 
 ## Export
 1. Click **Export** in the toolbar.
-2. Choose a component format: React or Web Component.
-3. Pick your downloads:
-   - **card.json** captures the card configuration.
-   - **openapi.yaml** lists the generated endpoints.
+2. Pick a component format:
+   - **React** for React projects.
+   - **Web Component** for any framework.
+3. Choose your downloads:
+   - **card.json** – captures the card’s configuration so you can reload or version it.
+   - **openapi.yaml** – documents the generated endpoints with an OpenAPI spec for client or server generation.
 4. Save the files to your project.
 
 ## Next steps

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -3,14 +3,17 @@
 Consistency keeps our guides accessible and easy to maintain. Follow these conventions when writing.
 
 ## Tone
-- Address the reader as "you" and use active voice.
-- Prefer short sentences and everyday language.
+- Write in the second person ("you") and stay in active voice.
+- Keep sentences short and confident.
+- Sound helpful without being formal; skip exclamation marks.
 
 ## Formatting
 - Start each page with an H1 title.
 - Use sentence case for headings.
+- Use ordered lists for sequences and bullet lists for options.
 - Wrap commands and code samples in fenced blocks.
 - Mention file formats in uppercase (`JSON`, `OpenAPI`).
+- Use relative links to other docs.
 
 ## Cross-links
 - Connect related topics. For export steps and JSON/OpenAPI downloads, see [Exporting Cards](./exporting-cards.md).

--- a/packages/card-builder/Technical_Writer-Morgan_Lee.md
+++ b/packages/card-builder/Technical_Writer-Morgan_Lee.md
@@ -14,9 +14,11 @@ Card Builder drew me in because every exported card is both prop and protagonist
 
 - **[2025-09-18]** Published the exporting guide with JSON and OpenAPI downloads and refreshed the style guide with cross-links.
 
+- **[2025-09-23]** Clarified JSON and OpenAPI exports, refreshed style guidance, and linked both docs from the platform README.
+
 ## What I’m Doing
 
-I'm gathering real-world examples of JSON and OpenAPI exports to guide the next revision.
+I'm gathering real-world examples of JSON and OpenAPI exports to guide the next revision and collecting feedback on the updated guides.
 
 ## Where I’m Headed
 


### PR DESCRIPTION
## Summary
- clarify card export steps with JSON and OpenAPI downloads
- expand documentation style guide for tone and formatting
- link guides from README and update Morgan Lee persona

## Testing
- `npm test` *(fails: Executable doesn't exist at /root/.cache/ms-playwright/webkit-2203/pw_run.sh)*

------
https://chatgpt.com/codex/tasks/task_e_68bb7359ff208331a0ed3f57e29166b1