### PR TITLE
docs: clarify card builder onboarding

### DIFF
--- a/packages/card-builder/AGENT.md
+++ b/packages/card-builder/AGENT.md
@@ -1,8 +1,17 @@
 # Card Builder AGENT Instructions
 
-- Always begin by reading `AGENT.md` to ensure you have the latest guidance.
-- Read `README.md` in this directory to understand project goals, personas, and roster.
-- Review each persona markdown file (`*_*.md`) to understand backgrounds and responsibilities before assigning work.
+## Orientation
+
+1. Always begin by reading `AGENT.md` to ensure you have the latest guidance.
+2. Read `README.md` in this directory to understand project goals, personas, and roster.
+3. Review each persona markdown file (`*_*.md`) to learn backgrounds and responsibilities before assigning work.
+
+## Task Planning
+
 - When proposing or assigning tasks, prefix each task with the responsible persona's full name.
-- Make the first suggested task: **"Read AGENT.md"** so future agents start with the current process.
+- Include a starter task stub: `- [ ] Read AGENT.md` so future agents begin with the current process.
+
+## Persona Updates
+
+- If your work affects a persona, append a dated note to the relevant persona file describing the change.
 

--- a/packages/card-builder/Product_Manager-Riley_Monroe.md
+++ b/packages/card-builder/Product_Manager-Riley_Monroe.md
@@ -13,6 +13,8 @@ What excites me about the **Card Builder** is its promise of giving anyone the p
 - **[2025‑09‑07]** Worked with Jade to define the look and feel of our editor and wrote the first draft of the Card Builder README.  Encouraged everyone to write in their persona files as if they were keeping a travel diary.
 - **[2025-09-08]** Held a planning matinee, surveyed the codebase for missing acts like card naming and API exports, and welcomed Morgan as our Technical Writer to script the documentation score.
 
+- **[2025-09-09]** Clarified onboarding in `AGENT.md` with orientation steps, task stubs, and a reminder to log persona profile updates.
+
 ## What I’m Doing
 
 I’m orchestrating our next sprint, spotlighting three numbers: intuitive card naming, a clearer API generator and documentation that reads like sheet music.  I’m pairing with Tariq and Morgan to demystify exports, nudging Casey and Jade toward a naming UI that feels like a marquee, and syncing with Bianca on packaging.  Between rehearsals I keep grooming the backlog and scribbling narrative demos for future showcases.


### PR DESCRIPTION
## Summary
- clarify orientation steps, task stub usage, and persona update process in AGENT.md
- log AGENT.md onboarding clarifications in Riley Monroe's persona profile

## Testing
- `npm test` *(fails: missing Playwright browsers)*
- `npx playwright install` *(fails: download server returned 403)*
- `npm run pre-commit`


------
https://chatgpt.com/codex/tasks/task_e_68bb7487e9108331a0164fc224cd400d