### PR TITLE
docs: reference runbook and track cross-team progress

### DIFF
--- a/packages/code-explorer/AGENT.md
+++ b/packages/code-explorer/AGENT.md
@@ -1,6 +1,7 @@
 # Code Explorer Process Guide
 
 - Keep role files updated with Past/Current/Future logs each sprint.
-- Before committing, run `npm test` and `npm run check`.
+- When adding features, reference the runbook (`docs/runbook.md`) for guidance.
+- Before committing, run `npm test`, `npx vitest run --root packages/code-explorer`, and `npm run check`.
 - Install Playwright browsers before running end-to-end tests (`npx playwright install`).
 - Sync backend, frontend, QA, and docs progress in weekly check-ins, and refine the roadmap accordingly.

--- a/packages/code-explorer/Product_Manager-Ava_Wu.md
+++ b/packages/code-explorer/Product_Manager-Ava_Wu.md
@@ -46,6 +46,7 @@ Preparing the code explorer package for beta launch and refining remaining featu
 - Backend delivered async/arrow function support and Function Browser entered drag-and-drop testing; QA expanded regression coverage and docs published updated runbook.
 - Backend finalized patch engine diff endpoint; frontend wired drag-and-drop card builder; QA cleared regression suite; docs drafted patch engine walkthrough.
 - Updated roadmap to prioritize collaborative editing and incremental parsing after sprint demo.
+- Held cross-team sync aligning backend API, frontend card builder wiring, QA regression tests, and docs runbook updates.
 ### Current
 - Driving cross-team development of card-builder and aligning integration with code explorer.
 - Prioritizing backlog for card-builder beta and tracking package dependencies.
@@ -53,6 +54,7 @@ Preparing the code explorer package for beta launch and refining remaining featu
 - Aligning incremental parsing research, release-note automation, and beta timeline for Code Explorer.
 - Coordinating backend optimizations and frontend integration for patch engine; QA expanding card-builder test coverage; docs iterating on beta guide.
 - Refining roadmap to sequence collaborative editing after patch engine stabilization.
+- Tracking cross-team dependencies for patch engine launch across backend endpoints, frontend UI, QA scripts, and docs.
 ### Future
 - Planning rollout strategy and metrics for card-builder adoption.
 - Mapping long-term roadmap for advanced card templates and collaborative editing.
@@ -60,3 +62,4 @@ Preparing the code explorer package for beta launch and refining remaining featu
 - Benchmark incremental AST parsing, wire changelog tooling into CI, and broaden test coverage for class methods and default exports.
 - Backend to implement conflict resolution and performance tuning; frontend to enable real-time preview; QA to automate patch engine end-to-end tests; docs to finalize launch playbook.
 - Schedule roadmap checkpoint after beta metrics to define collaborative editing scope.
+- Plan coordinated beta readiness review with backend, frontend, QA, and docs teams.


### PR DESCRIPTION
## Summary
- require runbook consultation and vitest checks in Code Explorer's AGENT
- log cross-team updates in Ava Wu's PM notes

## Testing
- `npx playwright install` *(fails: Domain forbidden)*
- `npm test`
- `npx vitest run --root packages/code-explorer` *(fails: 3 failed tests)*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68bb776539b48331bffa9a4c7754d59d