### PR TITLE
feat(card-builder): expose default name and tidy gallery

### DIFF
--- a/packages/card-builder/Frontend_Developer-Casey_Rivera.md
+++ b/packages/card-builder/Frontend_Developer-Casey_Rivera.md
@@ -20,6 +20,10 @@ I adore crafting interactions that feel tactile and alive.  Animations, responsi
 - **[2025-09-12]** Tidied the gallery by trimming card titles on save and teaching the delete button to clear localStorage when a card vanishes.
 - **[2025-09-13]** Threaded a reliable card name through the toolbar, save flow and localStorage. Added a gallery delete control that cleans state and storage in one sweep.
 
+- **[2025-09-14]** Unified the default card title across the editor and gallery so every new creation starts with the same blank slate. Swept localStorage after deletions to keep the shelf spotless.
+
+- **[2025-09-15]** Restored the element library export so the card builder boots without a blank screen, letting creators dive back into design.
+
 ## What I’m Doing
 
 With card titles now flowing from the toolbar to localStorage and the gallery, I'm circling back to refine the properties panel. I'm adding colour wheels, font selectors and dynamic controls that surface only the fields a creator needs. The salsa playlist stays on loop as I tune keyboard accessibility so every gesture has a key‑press twin.

--- a/packages/card-builder/src/App.tsx
+++ b/packages/card-builder/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { CardEditor, CardConfig, elementLibrary } from "./Editor";
+import { CardEditor, CardConfig, elementLibrary, DEFAULT_NAME } from "./Editor";
 import { ActionCard } from "./components/ActionCard";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -8,8 +8,6 @@ import { Plus, Edit, Trash } from "lucide-react";
 interface StoredCard extends CardConfig {
   id: string;
 }
-
-const DEFAULT_NAME = "Untitled Card";
 
 function PreviewCanvas({ theme, shadow, lighting, animation, children }: Omit<CardConfig, "elements" | "name"> & { children: React.ReactNode }) {
   const themeClass =

--- a/packages/card-builder/src/Editor.tsx
+++ b/packages/card-builder/src/Editor.tsx
@@ -15,8 +15,9 @@ import {
 } from "./export";
 
 export { buildConfig, parseConfig, exportAssets, type CardConfig } from "./export";
+export { elementLibrary };
 
-const DEFAULT_NAME = "Untitled Card";
+export const DEFAULT_NAME = "Untitled Card";
 
 export function CardEditor({
   initial,


### PR DESCRIPTION
## Summary
- export a DEFAULT_NAME constant from CardEditor and use it for toolbar input
- show card names in gallery and provide delete controls that purge localStorage
- re-export elementLibrary so the card builder dev server boots correctly
- log the improvements in Casey Rivera's persona

## Testing
- `npm run dev:card`
- `npm test` *(fails: browserType.launch: Executable doesn't exist ...)*
- `npm run pre-commit`


------
https://chatgpt.com/codex/tasks/task_e_68bb7709138c8331bcf6ad6d0d6c9d6a