### PR TITLE
docs: refine toolbar wireframes and style notes

### DIFF
--- a/docs/design/naming-export-delete.md
+++ b/docs/design/naming-export-delete.md
@@ -11,6 +11,7 @@ These sketches map the flow for naming cards, exporting them, and deleting saved
 - Name field auto-trims spaces and falls back to **Untitled Card**.
 - Export button opens a modal confirming assets and API bundle.
 - Export button is disabled until a non-empty name is provided.
+- Disabled state uses muted foreground/background tokens from Code Explorer's style system.
 
 ## Gallery: delete affordance
 ```
@@ -20,6 +21,7 @@ These sketches map the flow for naming cards, exporting them, and deleting saved
 ```
 - Trash icon appears on hover; clicking prompts a confirm dialog before removal.
 - Successful deletion fades the card out and cleans up localStorage.
+- Hover and fade timings follow Code Explorer's motion curve (`ease-out`, 150 ms).
 
 ## Interaction Notes
 
@@ -28,8 +30,10 @@ These sketches map the flow for naming cards, exporting them, and deleting saved
 - Casey Rivera: Ensure keyboard focus order flows from name field to export button.
 - Casey Rivera: Style disabled Export state when name field is empty.
 - Casey Rivera: Wire delete animation and confirmation dialog in the gallery.
+- Casey Rivera: Apply Code Explorer spacing (`gap-2`, `p-2`) and typography tokens for visual consistency.
 
 ### Tariq Al-Fulani
 - Tariq Al-Fulani: Read AGENT.md
 - Tariq Al-Fulani: Confirm export API accepts trimmed names and returns asset bundle details.
 - Tariq Al-Fulani: Provide endpoint or hook for gallery deletions to sync server state.
+- Tariq Al-Fulani: Surface style config if backend needs to broadcast theme updates.

--- a/packages/card-builder/UI_Designer-Jade_Nguyen.md
+++ b/packages/card-builder/UI_Designer-Jade_Nguyen.md
@@ -14,10 +14,11 @@ At the **Card Builder**, my mission is to make the editor feel like a studio whe
 - **[2025-09-08]** Sketched wireframes for the toolbar’s name field and export button, captured interaction notes for the team.
 - **[2025-09-13]** Finalised toolbar naming and export sketches and added a gallery delete wireframe in `docs/design/naming-export-delete.md`, leaving notes for Casey and Tariq.
 - **[2025-09-14]** Refined those wireframes with disabled Export states and backend sync details. Shared the updated interaction notes with Casey and Tariq.
+- **[2025-09-15]** Reviewed Code Explorer's style tokens and updated the naming/export/delete wireframes with spacing, typography and motion cues. Passed implementation notes to Casey and Tariq.
 
 ## What I’m Doing
 
-With the wireframes iterated, I'm shaping a clickable prototype for naming, export and gallery deletion. I'm pairing with Casey to finesse responsive layout and looping in Tariq to validate export payloads while we test the new notes.
+With the wireframes iterated, I'm shaping a clickable prototype for naming, export and gallery deletion. I'm pairing with Casey to finesse responsive layout, looping in Tariq to validate export payloads, and porting Code Explorer's style system to clean up the UI.
 
 ## Where I’m Headed
 


### PR DESCRIPTION
## Summary
- detail toolbar name and export button wireframes with style tokens and motion cues
- note Code Explorer spacing and typography for gallery delete and toolbar
- log new design progress in Jade Nguyen persona

## Testing
- `npm test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/webkit-2203/pw_run.sh)*

------
https://chatgpt.com/codex/tasks/task_e_68bb7b89c8c083318dad584d6b8ded37