### PR TITLE
docs: clarify exporting cards and style guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 See our key guides:
 
 - [Onboarding Guide](docs/onboarding.md) for setup, tests, and profile conventions.
-- [Exporting Cards](docs/exporting-cards.md) to download card modules with `JSON` or `OpenAPI` specs.
-- [Documentation Style Guide](docs/style-guide.md) for writing tone and formatting.
+- [Exporting Cards](docs/exporting-cards.md) explains how to grab the configuration `JSON` and matching `OpenAPI` spec.
+- [Documentation Style Guide](docs/style-guide.md) outlines tone and formatting.
 
 Install CodeMirror and its language packages with `npm install` so code snippets can be highlighted.
 

--- a/docs/exporting-cards.md
+++ b/docs/exporting-cards.md
@@ -1,25 +1,25 @@
 # Exporting Cards
 
-Turn a Card Builder creation into a reusable module that ships with its own API contract.
+Use Card Builder to package your design along with a matching API description.
 
 ## Before you start
-- Start the Card Builder locally:
+- Start Card Builder locally:
   ```bash
   npm run card-builder
   ```
 - Design your card on the canvas.
 
-## Export
+## Export steps
 1. Click **Export** in the toolbar.
-2. Pick a component format:
+2. Choose a component format:
    - **React** for React projects.
    - **Web Component** for any framework.
-3. Choose your downloads:
-   - **card.json** – captures the card’s configuration so you can reload or version it.
-   - **openapi.yaml** – documents the generated endpoints with an OpenAPI spec for client or server generation.
-4. Save the files to your project.
+3. Decide which files to download:
+   - **card.json** — snapshot of the card configuration for reloading or version control.
+   - **openapi.yaml** — OpenAPI spec describing every generated endpoint, perfect for client or server scaffolding.
+4. Save the files where your app can reach them.
 
 ## Next steps
-- Import the component into your application.
-- Wire the documented endpoints to your backend.
+- Import the component into your app and wire the endpoints described in `openapi.yaml`.
+- File names or API shapes changed? Regenerate exports to stay in sync.
 - Need writing tips? See the [Documentation Style Guide](./style-guide.md).

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -3,16 +3,19 @@
 Consistency keeps our guides accessible and easy to maintain. Follow these conventions when writing.
 
 ## Tone
-- Write in the second person ("you") and stay in active voice.
+- Write in the second person ("you") and stay in the present tense.
 - Keep sentences short and confident.
 - Sound helpful without being formal; skip exclamation marks.
+- Keep paragraphs under three sentences so pages feel light and scannable.
 
 ## Formatting
 - Start each page with an H1 title.
 - Use sentence case for headings.
 - Use ordered lists for sequences and bullet lists for options.
-- Wrap commands and code samples in fenced blocks.
+- Wrap commands and code samples in fenced blocks annotated with a language.
 - Mention file formats in uppercase (`JSON`, `OpenAPI`).
+- Bold UI labels and paths, and use code ticks for filenames.
+- Limit lines to ~80 characters to aid diffs.
 - Use relative links to other docs.
 
 ## Cross-links

--- a/packages/card-builder/Technical_Writer-Morgan_Lee.md
+++ b/packages/card-builder/Technical_Writer-Morgan_Lee.md
@@ -16,13 +16,15 @@ Card Builder drew me in because every exported card is both prop and protagonist
 
 - **[2025-09-23]** Clarified JSON and OpenAPI exports, refreshed style guidance, and linked both docs from the platform README.
 
+- **[2025-09-30]** Expanded the exporting guide with clearer JSON and OpenAPI download steps, tightened the style guide, and confirmed both links in the platform README.
+
 ## What I’m Doing
 
-I'm gathering real-world examples of JSON and OpenAPI exports to guide the next revision and collecting feedback on the updated guides.
+I'm collecting real-world export samples and planning narrative tutorials that show the specs in action.
 
 ## Where I’m Headed
 
-- Morgan Lee: Read AGENT.md
-- Morgan Lee: Collect team feedback on the exporting cards tutorial and style guide.
-- Morgan Lee: Collaborate with Tariq to auto-generate markdown docs alongside the API specs.
-- Morgan Lee: Develop narrative tutorials showing cards chatting with real backends, complete with diagrams and stage cues.
+- [ ] Morgan Lee: Read AGENT.md
+- [ ] Morgan Lee: Collect team feedback on the exporting cards tutorial and style guide.
+- [ ] Morgan Lee: Collaborate with Tariq to auto-generate markdown docs alongside the API specs.
+- [ ] Morgan Lee: Develop narrative tutorials showing cards chatting with real backends, complete with diagrams and stage cues.


### PR DESCRIPTION
## Summary
- expand exporting guide with explicit card.json and openapi.yaml steps
- refine documentation style guidance on tone and formatting
- link docs from main README and log work in Morgan Lee's persona

## Testing
- `npm test` *(fails: missing Playwright browser dependencies)*
- `npx playwright install` *(fails: 403 downloading browser binaries)*

------
https://chatgpt.com/codex/tasks/task_e_68bb7d1f2e548331bba60b1e0b9c2f0a