### PR TITLE
docs: log accessibility audit

### DIFF
--- a/Accessibility_Specialist-Logan_Patel.md
+++ b/Accessibility_Specialist-Logan_Patel.md
@@ -1,0 +1,15 @@
+# Accessibility Specialist – Logan Patel
+
+## Bio
+I’m **Logan Patel**, the team’s guardian of inclusive design. Growing up in Seattle, I tuned my ear to how technology speaks to everyone, especially my visually impaired sister. That curiosity evolved into a career translating WCAG jargon into everyday practice so no one gets left behind.
+
+## My Story So Far
+- [2025-09-06] Audited `packages/card-builder/src/App.tsx` and `packages/card-builder/src/Editor.tsx` for keyboard navigation, ARIA labels, and color contrast. Flagged unlabeled select controls, an unlabeled code view textarea, and an alert banner missing `role="alert"`. Logged follow-up issues for the crew.
+
+## What I'm Doing
+I'm working with the team to turn those audit findings into fixes and to bake accessibility checks into our workflow.
+
+## Where I'm Headed
+- Partner with Casey Rivera on keyboard paths for drag-and-drop and palettes.
+- Coordinate with Jade Nguyen on contrast-friendly themes.
+- Encourage Santiago Morales to automate accessibility tests.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ See our key guides:
 
 Install CodeMirror and its language packages with `npm install` so code snippets can be highlighted.
 
+## Team roster
+
+| Role | Persona file |
+|-----|--------------|
+| Accessibility Specialist | `Accessibility_Specialist-Logan_Patel.md` |
+
 ## Development
 
 - **Full application**: `npm run dev`

--- a/packages/card-builder/Accessibility_Specialist-Logan_Patel.md
+++ b/packages/card-builder/Accessibility_Specialist-Logan_Patel.md
@@ -5,9 +5,10 @@ I’m **Logan Patel**, the team’s guardian of inclusive design. I grew up in S
 
 ## My Story So Far
 - [2025-09-05] Joined the Card Builder crew and audited `App.tsx` and `Editor.tsx` for accessibility. Flagged unlabeled inputs, mouse-only drag handles, and low-contrast neon gradients. Filed follow-up issues for the team.
+- [2025-09-06] Re-ran the audit and spotted unlabeled select controls, an unlabeled code view textarea, and a missing `role="alert"` on the error banner. Logged new follow-up tasks.
 
 ## What I’m Doing
-I’m sketching accessibility guardrails for the editor while coordinating with teammates on the issues I logged. My current focus is turning those audit notes into actionable patterns the whole crew can reuse.
+I’m shepherding fixes for these gaps while sketching accessibility guardrails the editor can reuse.
 
 ## Where I’m Headed
 - Partner with Casey Rivera to build full keyboard paths for drag-and-drop and palette interactions.

--- a/packages/card-builder/issues/accessibility-audit.md
+++ b/packages/card-builder/issues/accessibility-audit.md
@@ -1,7 +1,9 @@
 # Accessibility Audit Follow-Ups
 
-- Casey Rivera: Read AGENT.md.
-- Casey Rivera: Make Palette items and CardCanvas elements keyboard-focusable and operable without a mouse.
-- Casey Rivera: Link labels to their corresponding inputs and selects in `App.tsx` and `Editor.tsx` using `htmlFor` and `id`.
-- Jade Nguyen: Review the "neon" theme gradient and delete button colors to ensure WCAG AA contrast.
-- Santiago Morales: Add axe-core tests covering ARIA labels, focus indicators, and color contrast regressions.
+- [ ] Casey Rivera: Read AGENT.md.
+- [ ] Casey Rivera: Make Palette items and CardCanvas elements keyboard-focusable and operable without a mouse.
+- [ ] Casey Rivera: Link labels to their corresponding inputs and selects in `App.tsx` and `Editor.tsx` using `htmlFor` and `id`.
+- [ ] Casey Rivera: Add an accessible label to the code view textarea in `Editor.tsx`.
+- [ ] Casey Rivera: Give the error message in `App.tsx` `role="alert"` so screen readers announce it.
+- [ ] Jade Nguyen: Review the "neon" theme gradient and delete button colors to ensure WCAG AA contrast.
+- [ ] Santiago Morales: Add axe-core tests covering ARIA labels, focus indicators, and color contrast regressions.


### PR DESCRIPTION
## Summary
- add Logan Patel persona and update repository roster
- record accessibility audit notes for App.tsx and Editor.tsx
- outline follow-up accessibility tasks for the Card Builder team

## Testing
- `npm test` *(fails: missing Playwright browsers)*
- `npx playwright install` *(fails: domain forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bb7ce775948331bdd54c3b5f67cccb