### PR TITLE
feat(code-explorer): index class methods and defaults

### DIFF
--- a/packages/code-explorer/Tech_Lead-Jordan_Rowe.md
+++ b/packages/code-explorer/Tech_Lead-Jordan_Rowe.md
@@ -70,7 +70,7 @@ Coordinating integration of code exploration features while aligning documentati
 
 
 ## 🔄 Status
-- **Past:** Converted `scan.js` utilities into the `/code-explorer/api/functions` endpoint indexing declared, arrow, and async functions with tag filtering.
-- **Current:** Expanding unit tests to cover typical and edge cases for the functions endpoint.
-- **Future:** Investigate incremental parsing and broaden coverage for class methods and default exports.
+- **Past:** Extended `scan.js` to capture class methods and default-exported functions with tagging.
+- **Current:** Finalizing tests and type checks for the enhanced scanner.
+- **Future:** Explore incremental parsing strategies and optimize class method indexing.
 

--- a/packages/code-explorer/__tests__/scan.test.ts
+++ b/packages/code-explorer/__tests__/scan.test.ts
@@ -15,7 +15,9 @@ beforeAll(() => {
       "function decl(a: number, b: number): number { return a + b; }",
       "const arrow = (x: string) => x;",
       "const asyncArrow = async () => {};",
-      "export default function () {}",
+      "class MyClass { method() {} }",
+      "export default function defaultDecl() {}",
+      "export default () => {}",
       "function* gen() {}",
       "async function* asyncGen() {}",
     ].join("\n"),
@@ -27,7 +29,7 @@ afterAll(() => {
 });
 
 describe("scan", () => {
-  it("parses functions and skips anonymous defaults", () => {
+  it("parses functions including class methods and defaults", () => {
     const result = scan(dir);
     expect(result).toEqual([
       {
@@ -47,6 +49,24 @@ describe("scan", () => {
         signature: "async asyncArrow(): any",
         path: "sample.ts",
         tags: [],
+      },
+      {
+        name: "MyClass.method",
+        signature: "MyClass.method(): any",
+        path: "sample.ts",
+        tags: ["class-method"],
+      },
+      {
+        name: "defaultDecl",
+        signature: "defaultDecl(): any",
+        path: "sample.ts",
+        tags: ["default-export"],
+      },
+      {
+        name: "default",
+        signature: "default(): any",
+        path: "sample.ts",
+        tags: ["default-export"],
       },
       {
         name: "gen",

--- a/packages/code-explorer/scan.js
+++ b/packages/code-explorer/scan.js
@@ -48,11 +48,13 @@ function parseFile(file, rootDir) {
     jsDocNode,
     isAsync = false,
     isGenerator = false,
+    extraTags = [],
   ) {
-    const tags = ts
+    const jsDocTags = ts
       .getJSDocTags(jsDocNode)
       .filter((t) => t.tagName.getText(sourceFile) === 'tag')
       .map((t) => (t.comment ?? '').toString());
+    const tags = [...jsDocTags, ...extraTags];
     functions.push({
       name,
       signature: `${isAsync ? 'async ' : ''}${isGenerator ? '*' : ''}${name}(${params}): ${returnType}`,
@@ -62,14 +64,46 @@ function parseFile(file, rootDir) {
   }
 
   function visit(node) {
-    if (ts.isFunctionDeclaration(node) && node.name) {
+    if (ts.isFunctionDeclaration(node)) {
       const paramsText = node.parameters
         .map((p) => p.getText(sourceFile))
         .join(', ');
       const returnType = node.type ? node.type.getText(sourceFile) : 'any';
       const isAsync = node.modifiers?.some((m) => m.kind === ts.SyntaxKind.AsyncKeyword) ?? false;
       const isGenerator = !!node.asteriskToken;
-      addFunction(node.name.text, paramsText, returnType, node, isAsync, isGenerator);
+      const isDefault =
+        node.modifiers?.some((m) => m.kind === ts.SyntaxKind.DefaultKeyword) ?? false;
+      const name = node.name ? node.name.text : isDefault ? 'default' : null;
+      if (name) {
+        const extraTags = isDefault ? ['default-export'] : [];
+        addFunction(name, paramsText, returnType, node, isAsync, isGenerator, extraTags);
+      }
+    } else if (ts.isClassDeclaration(node) && node.name) {
+      const className = node.name.text;
+      for (const member of node.members) {
+        if (
+          ts.isMethodDeclaration(member) &&
+          member.name &&
+          ts.isIdentifier(member.name)
+        ) {
+          const paramsText = member.parameters
+            .map((p) => p.getText(sourceFile))
+            .join(', ');
+          const returnType = member.type ? member.type.getText(sourceFile) : 'any';
+          const isAsync =
+            member.modifiers?.some((m) => m.kind === ts.SyntaxKind.AsyncKeyword) ?? false;
+          const isGenerator = !!member.asteriskToken;
+          addFunction(
+            `${className}.${member.name.text}`,
+            paramsText,
+            returnType,
+            member,
+            isAsync,
+            isGenerator,
+            ['class-method'],
+          );
+        }
+      }
     } else if (
       ts.isVariableDeclaration(node) &&
       ts.isIdentifier(node.name) &&
@@ -92,6 +126,26 @@ function parseFile(file, rootDir) {
         isAsync,
         isGenerator,
       );
+    } else if (ts.isExportAssignment(node)) {
+      const expr = node.expression;
+      if (ts.isArrowFunction(expr) || ts.isFunctionExpression(expr)) {
+        const paramsText = expr.parameters
+          .map((p) => p.getText(sourceFile))
+          .join(', ');
+        const returnType = expr.type ? expr.type.getText(sourceFile) : 'any';
+        const isAsync =
+          expr.modifiers?.some((m) => m.kind === ts.SyntaxKind.AsyncKeyword) ?? false;
+        const isGenerator = ts.isFunctionExpression(expr) && !!expr.asteriskToken;
+        addFunction(
+          'default',
+          paramsText,
+          returnType,
+          node,
+          isAsync,
+          isGenerator,
+          ['default-export'],
+        );
+      }
     }
     ts.forEachChild(node, visit);
   }


### PR DESCRIPTION
## Summary
- extend scanner to tag class methods and default-exported functions
- cover new function types with unit tests
- update tech lead status notes

## Testing
- `npx playwright install` *(fails: Download failed: server returned code 403)*
- `npm test`
- `npx vitest run --root packages/code-explorer` *(fails: 3 failed | 12 passed (15))*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68bc6bcecd1c833191c9b911c5793ede