### PR TITLE
feat(code-explorer): add tag filtering to function browser

### DIFF
--- a/packages/code-explorer/Frontend_Developer-Simon_Hesher.md
+++ b/packages/code-explorer/Frontend_Developer-Simon_Hesher.md
@@ -73,3 +73,10 @@ drag-and-drop libraries, and dependency graph automation.
 
 ## 🚨 Urgent Notes
 
+## 🕒 Frontend Development Log
+### Past
+- Implemented tag rendering and tag-based filtering in the Function Browser with accompanying tests.
+### Current
+- Refining component filtering controls and verifying accessibility of new tag inputs.
+### Future
+- Explore multi-select tag filters and animated transitions between explorer panels.

--- a/packages/code-explorer/src/components/FunctionBrowser.test.tsx
+++ b/packages/code-explorer/src/components/FunctionBrowser.test.tsx
@@ -24,11 +24,12 @@ describe("FunctionBrowser", () => {
     await waitFor(() => {
       const items = screen
         .queryAllByTestId(/function-/)
-        .filter(
-          (el) =>
-            !["function-browser", "function-search"].includes(
-              el.getAttribute("data-testid")!
-            ),
+        .filter((el) =>
+          ![
+            "function-browser",
+            "function-search",
+            "function-tag-filter",
+          ].includes(el.getAttribute("data-testid")!),
         );
       expect(items).toHaveLength(0);
     });
@@ -44,11 +45,12 @@ describe("FunctionBrowser", () => {
     await waitFor(() => {
       const items = screen
         .queryAllByTestId(/function-/)
-        .filter(
-          (el) =>
-            !["function-browser", "function-search"].includes(
-              el.getAttribute("data-testid")!,
-            ),
+        .filter((el) =>
+          ![
+            "function-browser",
+            "function-search",
+            "function-tag-filter",
+          ].includes(el.getAttribute("data-testid")!),
         );
       expect(items).toHaveLength(0);
     });
@@ -118,6 +120,47 @@ describe("FunctionBrowser", () => {
     });
 
     expect(screen.getByTestId("function-foo")).toBeTruthy();
+    expect(screen.getByTestId("function-bar")).toBeTruthy();
+  });
+
+  it("renders tags for each function", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      json: () =>
+        Promise.resolve([
+          {
+            name: "foo",
+            signature: "",
+            path: "a.ts",
+            tags: ["math", "util"],
+          },
+        ]),
+    } as any);
+
+    render(<FunctionBrowser />);
+
+    const item = await screen.findByTestId("function-foo");
+    expect(within(item).getByText("math")).toBeTruthy();
+    expect(within(item).getByText("util")).toBeTruthy();
+  });
+
+  it("filters by tag", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      json: () =>
+        Promise.resolve([
+          { name: "foo", signature: "", path: "a.ts", tags: ["alpha"] },
+          { name: "bar", signature: "", path: "b.ts", tags: ["beta"] },
+        ]),
+    } as any);
+
+    render(<FunctionBrowser />);
+
+    await screen.findByTestId("function-foo");
+
+    fireEvent.change(screen.getByTestId("function-tag-filter"), {
+      target: { value: "beta" },
+    });
+
+    expect(screen.queryByTestId("function-foo")).toBeNull();
     expect(screen.getByTestId("function-bar")).toBeTruthy();
   });
 

--- a/packages/code-explorer/src/components/FunctionBrowser.tsx
+++ b/packages/code-explorer/src/components/FunctionBrowser.tsx
@@ -17,6 +17,7 @@ interface Props {
 export function FunctionBrowser({ onSelect }: Props) {
   const [functions, setFunctions] = useState<FunctionMeta[]>([]);
   const [query, setQuery] = useState("");
+  const [tagQuery, setTagQuery] = useState("");
 
   useEffect(() => {
     fetch("/code-explorer/api/functions")
@@ -25,19 +26,32 @@ export function FunctionBrowser({ onSelect }: Props) {
       .catch(() => setFunctions([]));
   }, []);
 
-  const filtered = functions.filter((f) =>
-    f.name.toLowerCase().includes(query.toLowerCase())
-  );
+  const filtered = functions.filter((f) => {
+    const matchesName = f.name.toLowerCase().includes(query.toLowerCase());
+    const matchesTag =
+      tagQuery === "" ||
+      f.tags.map((t) => t.toLowerCase()).includes(tagQuery.toLowerCase());
+    return matchesName && matchesTag;
+  });
 
   return (
     <div className="w-32 border-r p-2" data-testid="function-browser">
-      <input
-        className="mb-2 w-full border rounded px-1 py-0.5 text-xs"
-        placeholder="Search..."
-        value={query}
-        onChange={(e) => setQuery(e.target.value)}
-        data-testid="function-search"
-      />
+      <div className="mb-2 flex gap-1">
+        <input
+          className="w-full border rounded px-1 py-0.5 text-xs"
+          placeholder="Search..."
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          data-testid="function-search"
+        />
+        <input
+          className="w-full border rounded px-1 py-0.5 text-xs"
+          placeholder="Tag"
+          value={tagQuery}
+          onChange={(e) => setTagQuery(e.target.value)}
+          data-testid="function-tag-filter"
+        />
+      </div>
       {filtered.map((fn) => (
         <div
           key={`${fn.path}-${fn.name}`}
@@ -49,7 +63,20 @@ export function FunctionBrowser({ onSelect }: Props) {
           }}
           className="p-2 mb-2 border rounded bg-background cursor-move text-xs"
         >
-          {fn.name}
+          <div>{fn.name}</div>
+          {fn.tags?.length > 0 && (
+            <div className="mt-1 flex flex-wrap gap-1" data-testid="function-tags">
+              {fn.tags.map((tag) => (
+                <span
+                  key={tag}
+                  className="rounded bg-muted px-1 text-[10px]"
+                  data-testid={`function-tag-${tag}`}
+                >
+                  {tag}
+                </span>
+              ))}
+            </div>
+          )}
         </div>
       ))}
     </div>


### PR DESCRIPTION
## Summary
- render tags for each function and add tag-based filter alongside search
- test tag rendering and filtering in FunctionBrowser
- log tag filter work in Frontend_Developer-Simon_Hesher.md

## Testing
- `npx playwright install` *(fails: Domain forbidden)*
- `npm test` *(fails: Domain forbidden)*
- `npx vitest run --root packages/code-explorer` *(fails: 3 failed test files)*
- `npm run check` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bc6d3de1808331b9755a83587b2435