### PR TITLE
test: cover tagged functions and index metadata

### DIFF
--- a/client/src/__tests__/functions-api.test.ts
+++ b/client/src/__tests__/functions-api.test.ts
@@ -17,4 +17,9 @@ describe("/api/functions", () => {
     expect(data.length).toBeGreaterThan(0);
     server.close();
   });
+
+  it("includes class methods and default exports", () => {
+    expect(functionIndex.some((f) => f.tags.includes("class-method"))).toBe(true);
+    expect(functionIndex.some((f) => f.tags.includes("default-export"))).toBe(true);
+  });
 });

--- a/packages/code-explorer/QA_Engineer-Maria_Li.md
+++ b/packages/code-explorer/QA_Engineer-Maria_Li.md
@@ -22,9 +22,9 @@ Maria brings a detail-oriented mindset shaped by years of testing complex web ap
 Prioritizing regression tests for large directory scans with nested symlinks and files without extensions.
 
 ## 🔄 Status
-- **Past:** Added regression tests covering nested symlink directories and extensionless files in the save/patch flow.
-- **Current:** Extending tests for endpoint failure states and drag-and-drop between FunctionBrowser and CompositionCanvas.
-- **Future:** Automate Playwright runs in CI to validate drag-and-drop interactions across browsers.
+- **Past:** Extending tests for endpoint failure states and drag-and-drop between FunctionBrowser and CompositionCanvas.
+- **Current:** Adding tag-filter coverage and verifying index entries for class methods and default exports.
+- **Future:** Automate Playwright runs in CI to validate tag-based drag-and-drop interactions across browsers.
 
 ## 📝 Current Task Notes
 - Added regression tests covering nested symlink directories and extensionless files in the save/patch flow.
@@ -34,6 +34,7 @@ Prioritizing regression tests for large directory scans with nested symlinks and
 - Playwright run in this environment fails to launch browsers; set up `npx playwright install` in CI.
 - Added Playwright tests for API 500 responses and multi-function drag-and-drop between FunctionBrowser and CompositionCanvas; unit tests and type-checks pass, Playwright tests fail to launch browsers locally.
 - Extended component and Playwright tests to cover 404 function endpoint errors and duplicate function drag-and-drop on the CompositionCanvas; unit tests and type checks pass.
+- Added case-insensitive tag filtering tests, index coverage for class-method and default-export entries, and a tagged drag-and-drop scenario.
 
 ## 🗂️ Project Notes
 - Completed review of recent bug reports to design targeted tests.

--- a/packages/code-explorer/e2e/function-browser.spec.tsx
+++ b/packages/code-explorer/e2e/function-browser.spec.tsx
@@ -63,6 +63,41 @@ test('handles API failure gracefully', async ({ mount, page }) => {
     await expect(component.getByText('foo')).toBeVisible();
   });
 
+  test('drags tagged function to canvas', async ({ mount, page }) => {
+    await page.route('**/api/functions', route =>
+      route.fulfill({
+        status: 200,
+        body: JSON.stringify([
+          { name: 'foo', signature: '', path: 'a.ts', tags: ['util'] }
+        ])
+      })
+    );
+
+    const Wrapper = () => {
+      const [state, setState] = React.useState({
+        nodes: [] as CompositionNode[],
+        connections: [] as Edge[],
+      });
+      return (
+        <div className="flex">
+          <FunctionBrowser />
+          <CompositionCanvas
+            nodes={state.nodes}
+            connections={state.connections}
+            onUpdate={setState}
+          />
+        </div>
+      );
+    };
+
+    const component = await mount(<Wrapper />);
+    const fn = component.locator('[data-testid="function-foo"]');
+    await expect(fn.locator('[data-testid="function-tag-util"]').first()).toBeVisible();
+    const canvas = component.locator('[data-testid="canvas"]');
+    await fn.dragTo(canvas);
+    await expect(component.getByText('foo')).toBeVisible();
+  });
+
   test('drags multiple functions to canvas', async ({ mount, page }) => {
     await page.route('**/api/functions', route =>
       route.fulfill({

--- a/packages/code-explorer/src/components/FunctionBrowser.test.tsx
+++ b/packages/code-explorer/src/components/FunctionBrowser.test.tsx
@@ -164,6 +164,27 @@ describe("FunctionBrowser", () => {
     expect(screen.getByTestId("function-bar")).toBeTruthy();
   });
 
+  it("filters by tag case-insensitively", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      json: () =>
+        Promise.resolve([
+          { name: "foo", signature: "", path: "a.ts", tags: ["Alpha"] },
+          { name: "bar", signature: "", path: "b.ts", tags: ["Beta"] },
+        ]),
+    } as any);
+
+    render(<FunctionBrowser />);
+
+    await screen.findByTestId("function-foo");
+
+    fireEvent.change(screen.getByTestId("function-tag-filter"), {
+      target: { value: "beta" },
+    });
+
+    expect(screen.queryByTestId("function-foo")).toBeNull();
+    expect(screen.getByTestId("function-bar")).toBeTruthy();
+  });
+
   it("drags function to composition canvas", async () => {
     global.fetch = vi.fn().mockResolvedValue({
       json: () =>


### PR DESCRIPTION
## Summary
- add case-insensitive tag filtering spec for FunctionBrowser
- ensure function index exposes class-method and default-export entries
- exercise drag-and-drop for tagged functions in Playwright
- log updated QA tasks for Maria Li

## Testing
- `npm test`
- `npx vitest run --root packages/code-explorer` (fails: error when mocking modules)
- `npm run check` (fails: TypeScript errors in server)
- `npx playwright install` (fails: download failed 403)
- `npx playwright test` (fails: component testing template missing)

------
https://chatgpt.com/codex/tasks/task_e_68bc6ec17fd08331a440c5cff7f2d38b