### PR TITLE
docs: document tagging workflow

### DIFF
--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -33,14 +33,21 @@ This guide covers setting up the project locally, running tests, and establishin
 ## Function Index & `FunctionBrowser` Flow
 
 - `GET /api/functions` returns the prebuilt **function index** generated at startup by `server/function-index.ts`.
+- The index includes standalone functions, class methods, and default exports. Class methods are named `ClassName.method`; default exports appear as `default` and receive the `default-export` tag.
+- Functions can carry custom metadata with JSDoc tags:
+  ```ts
+  /** @tag util */
+  export function add(a: number, b: number) { return a + b; }
+  ```
+- Sample response:
   ```json
   [
-    { "name": "add", "path": "src/math.ts", "line": 12, "tags": ["math"] }
+    { "name": "add", "path": "src/math.ts", "line": 12, "tags": ["math", "util"] }
   ]
   ```
-- The `FunctionBrowser` panel uses this endpoint to enable search, filtering, and drag-and-drop:
+- The `FunctionBrowser` panel uses this endpoint to enable search, tag filtering, and drag-and-drop:
   1. Open the browser from the explorer sidebar.
-  2. Search or filter to find a function.
+  2. Enter a tag or search term to find a function.
   3. Drag the function onto the `CompositionCanvas` to begin a new flow.
 
 ## Profile Conventions

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -13,13 +13,19 @@ The script inspects git tags in chronological order, groups commits by type, and
 ## Function Index & `FunctionBrowser` Flow
 
 - `GET /api/functions` exposes the prebuilt **function index** generated at startup by `server/function-index.ts`. Each entry lists a function's name, file path, line number, and optional tags.
+- The index captures standalone functions, class methods, and default exports. Class methods are stored as `ClassName.method` and default-exported functions use the name `default` and include the `default-export` tag.
+- Functions can include custom tags via JSDoc:
+  ```ts
+  /** @tag util */
+  export function add(a: number, b: number) { return a + b; }
+  ```
 - Sample response:
   ```json
   [
-    { "name": "add", "path": "src/math.ts", "line": 12, "tags": ["math"] }
+    { "name": "add", "path": "src/math.ts", "line": 12, "tags": ["math", "util"] }
   ]
   ```
-- The `FunctionBrowser` panel queries this endpoint and supports search, filtering, and drag-and-drop:
+- The `FunctionBrowser` panel queries this endpoint and supports search, tag filtering, and drag-and-drop:
   1. Open the browser from the explorer sidebar.
-  2. Search or filter to locate a function.
+  2. Enter a tag or search term to locate a function.
   3. Drag the function onto the `CompositionCanvas` to start a flow.

--- a/packages/code-explorer/Documentation_Ops-Alex_Kim.md
+++ b/packages/code-explorer/Documentation_Ops-Alex_Kim.md
@@ -36,6 +36,11 @@ Standardize repository documentation and automate release notes.
 
 ## 🚨 Urgent Notes
 
+## 🔄 Status
+
+- **Past:** Published runbook and onboarding docs covering function index basics.
+- **Current:** Documenting class method and default-export indexing along with tag filters.
+- **Future:** Automate changelog tagging and keep cross-team docs aligned.
 
 ## 🔧 Maintenance Plan
 - Review documentation monthly for accuracy.

--- a/packages/code-explorer/scripts/generate-changelog.js
+++ b/packages/code-explorer/scripts/generate-changelog.js
@@ -13,6 +13,7 @@ const typeMap = {
   ci: 'CI',
   perf: 'Performance',
   style: 'Styles',
+  tag: 'Tag Enhancements',
   other: 'Other',
 };
 
@@ -45,7 +46,12 @@ function getCommits(from, to) {
 function parseCommit(message) {
   const match = message.match(/^(\w+)(?:\([^)]+\))?:\s*(.+)$/);
   if (match) {
-    return { type: match[1], description: match[2] };
+    let type = match[1];
+    const description = match[2];
+    if (description.toLowerCase().includes('tag')) {
+      type = 'tag';
+    }
+    return { type, description };
   }
   return { type: 'other', description: message };
 }


### PR DESCRIPTION
## Summary
- document how class methods, default exports, and JSDoc `@tag` annotations appear in the function index and FunctionBrowser
- categorize tag enhancements in the changelog generator
- log current tagging work in Documentation_Ops-Alex_Kim profile

## Testing
- `npm test`
- `npx vitest run --root packages/code-explorer` *(fails: missing modules and scan assertions)*
- `npm run check` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bc70552bf88331a0633d898009b431