### PR TITLE
tag: document tag indexing and changelog support

### DIFF
--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -33,8 +33,8 @@ This guide covers setting up the project locally, running tests, and establishin
 ## Function Index & `FunctionBrowser` Flow
 
 - `GET /api/functions` returns the prebuilt **function index** generated at startup by `server/function-index.ts`.
-- The index includes standalone functions, class methods, and default exports. Class methods are named `ClassName.method`; default exports appear as `default` and receive the `default-export` tag.
-- Functions can carry custom metadata with JSDoc tags:
+- The index includes standalone functions, class methods, and default exports. Class methods appear as `ClassName.method`, while default exports are recorded as `default` and automatically tagged with `default-export`.
+- Functions can carry custom metadata with JSDoc `@tag`; these tags feed the `FunctionBrowser` filter:
   ```ts
   /** @tag util */
   export function add(a: number, b: number) { return a + b; }
@@ -47,7 +47,7 @@ This guide covers setting up the project locally, running tests, and establishin
   ```
 - The `FunctionBrowser` panel uses this endpoint to enable search, tag filtering, and drag-and-drop:
   1. Open the browser from the explorer sidebar.
-  2. Enter a tag or search term to find a function.
+  2. Use the tag filter or search field to find a function by name or `@tag`.
   3. Drag the function onto the `CompositionCanvas` to begin a new flow.
 
 ## Profile Conventions

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -13,8 +13,8 @@ The script inspects git tags in chronological order, groups commits by type, and
 ## Function Index & `FunctionBrowser` Flow
 
 - `GET /api/functions` exposes the prebuilt **function index** generated at startup by `server/function-index.ts`. Each entry lists a function's name, file path, line number, and optional tags.
-- The index captures standalone functions, class methods, and default exports. Class methods are stored as `ClassName.method` and default-exported functions use the name `default` and include the `default-export` tag.
-- Functions can include custom tags via JSDoc:
+- The index captures standalone functions, class methods, and default exports. Class methods appear as `ClassName.method`, while default exports are recorded as `default` and automatically tagged with `default-export`.
+- Functions can include custom tags via JSDoc. These tags power the filter in `FunctionBrowser`:
   ```ts
   /** @tag util */
   export function add(a: number, b: number) { return a + b; }
@@ -27,5 +27,5 @@ The script inspects git tags in chronological order, groups commits by type, and
   ```
 - The `FunctionBrowser` panel queries this endpoint and supports search, tag filtering, and drag-and-drop:
   1. Open the browser from the explorer sidebar.
-  2. Enter a tag or search term to locate a function.
+  2. Use the tag filter or search field to locate a function by name or `@tag`.
   3. Drag the function onto the `CompositionCanvas` to start a flow.

--- a/packages/code-explorer/Documentation_Ops-Alex_Kim.md
+++ b/packages/code-explorer/Documentation_Ops-Alex_Kim.md
@@ -38,8 +38,8 @@ Standardize repository documentation and automate release notes.
 
 ## 🔄 Status
 
-- **Past:** Published runbook and onboarding docs covering function index basics.
-- **Current:** Documenting class method and default-export indexing along with tag filters.
+- **Past:** Published runbook and onboarding docs covering function index basics and tag filter usage.
+- **Current:** Refining changelog script to surface tag enhancements.
 - **Future:** Automate changelog tagging and keep cross-team docs aligned.
 
 ## 🔧 Maintenance Plan

--- a/packages/code-explorer/scripts/generate-changelog.js
+++ b/packages/code-explorer/scripts/generate-changelog.js
@@ -2,6 +2,8 @@ import { execSync } from 'node:child_process';
 import { writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
+// Map conventional commit types to changelog section headings. Tag-related commits are
+// grouped under "Tag Enhancements" to highlight improvements around `@tag` support.
 const typeMap = {
   feat: 'Features',
   fix: 'Bug Fixes',
@@ -14,6 +16,7 @@ const typeMap = {
   perf: 'Performance',
   style: 'Styles',
   tag: 'Tag Enhancements',
+  tags: 'Tag Enhancements',
   other: 'Other',
 };
 
@@ -48,6 +51,7 @@ function parseCommit(message) {
   if (match) {
     let type = match[1];
     const description = match[2];
+    if (type === 'tags') type = 'tag';
     if (description.toLowerCase().includes('tag')) {
       type = 'tag';
     }


### PR DESCRIPTION
## Summary
- explain how class methods, default exports, and @tag metadata are indexed in runbook and onboarding docs
- note tag filter usage in FunctionBrowser
- highlight tag-related changes in changelog script and update Documentation_Ops log

## Testing
- `npx playwright install` *(fails: Download failed: server returned code 403 body 'Domain forbidden')*
- `npm test`
- `npx vitest run --root packages/code-explorer` *(fails: node_modules/@uiw/react-codemirror/src/__tests__/index.test.tsx ...)*
- `npm run check` *(fails: TS2304: Cannot find name 'siteAccessControl'...)*

------
https://chatgpt.com/codex/tasks/task_e_68bc746459bc8331b90d981de4b17a7a