### PR TITLE
Handle form field query errors

### DIFF
--- a/Codex.md
+++ b/Codex.md
@@ -4,4 +4,6 @@
 
 - Enabled unauthenticated retrieval of form template fields and sanitized the response to expose only public field data, excluding internal attributes like system flags and timestamps.
 - Added a unit test confirming the endpoint’s sanitized output and public accessibility without authentication.
+- Captured `isError` and `error` from the form field query so the modal can detect when loading fails.
+- Displayed a descriptive error message with retry and close options instead of form fields when the query fails.
 

--- a/client/src/pages/dynamic-site.tsx
+++ b/client/src/pages/dynamic-site.tsx
@@ -130,10 +130,39 @@ function DynamicFormModal({ isOpen, onClose, formTemplate, siteId, colorTheme }:
   const config = formTemplate.config || {};
 
   // Fetch the actual form template fields
-  const { data: formFields = [], isLoading } = useQuery<any[]>({
+  const {
+    data: formFields = [],
+    isLoading,
+    isError,
+    error,
+    refetch,
+  } = useQuery<any[]>({
     queryKey: [`/api/form-templates/${formTemplate.id}/fields`],
     enabled: !!formTemplate.id && isOpen,
   });
+
+  if (isError) {
+    return (
+      <Dialog open={isOpen} onOpenChange={onClose}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Failed to load form</DialogTitle>
+            <DialogDescription>
+              {error instanceof Error
+                ? error.message
+                : "An unexpected error occurred while loading the form."}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex justify-end gap-2 pt-4">
+            <Button variant="outline" onClick={onClose}>
+              Close
+            </Button>
+            <Button onClick={() => refetch()}>Retry</Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    );
+  }
 
   // Create dynamic form schema based on actual fields
   const createDynamicSchema = () => {


### PR DESCRIPTION
## Summary
- handle `useQuery` errors in DynamicFormModal
- show retry/close options instead of form fields when loading fails
- document error handling in Codex summary

## Testing
- `npm test` *(fails: 36 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc41094648331b92a8b19c0c4a079