### PR TITLE
Safeguard dynamic form generation against malformed fields

### DIFF
--- a/Codex.md
+++ b/Codex.md
@@ -6,4 +6,5 @@
 - Added a unit test confirming the endpoint’s sanitized output and public accessibility without authentication.
 - Captured `isError` and `error` from the form field query so the modal can detect when loading fails.
 - Displayed a descriptive error message with retry and close options instead of form fields when the query fails.
+- Validated dynamic form fields before schema and default value construction, skipping malformed entries to avoid runtime errors.
 

--- a/client/src/pages/dynamic-site.tsx
+++ b/client/src/pages/dynamic-site.tsx
@@ -168,7 +168,11 @@ function DynamicFormModal({ isOpen, onClose, formTemplate, siteId, colorTheme }:
   const createDynamicSchema = () => {
     let schemaFields: any = {};
     
-    formFields.forEach((field) => {
+    formFields.forEach((field, index) => {
+      if (!field?.fieldLibrary || !field.fieldLibrary.name) {
+        console.warn('Skipping malformed field entry', { index, field });
+        return;
+      }
       const fieldName = field.fieldLibrary.name;
       let fieldSchema: any;
       
@@ -275,7 +279,11 @@ function DynamicFormModal({ isOpen, onClose, formTemplate, siteId, colorTheme }:
   const createDefaultValues = () => {
     let defaultValues: any = {};
     
-    formFields.forEach((field) => {
+    formFields.forEach((field, index) => {
+      if (!field?.fieldLibrary || !field.fieldLibrary.name) {
+        console.warn('Skipping malformed field entry', { index, field });
+        return;
+      }
       const fieldName = field.fieldLibrary.name;
       // Array fields should default to empty array, others to empty string
       defaultValues[fieldName] = field.fieldLibrary.dataType === 'array' ? [] : "";


### PR DESCRIPTION
## Summary
- guard against malformed field entries when building dynamic form schema and default values
- document dynamic field validation in Codex

## Testing
- `npm test` *(fails: 36 failed, see logs)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc602b7788331b31b919554c42b69