### PR TITLE
feat: add public api request helper

### DIFF
--- a/Codex.md
+++ b/Codex.md
@@ -7,4 +7,5 @@
 - Captured `isError` and `error` from the form field query so the modal can detect when loading fails.
 - Displayed a descriptive error message with retry and close options instead of form fields when the query fails.
 - Validated dynamic form fields before schema and default value construction, skipping malformed entries to avoid runtime errors.
+- Introduced `publicApiRequest` helper to fetch form fields without cookies and updated form modals to use it.
 

--- a/client/src/components/simple-form-modal.tsx
+++ b/client/src/components/simple-form-modal.tsx
@@ -9,7 +9,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/comp
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useQuery, useMutation } from '@tanstack/react-query';
-import { apiRequest } from '@/lib/queryClient';
+import { apiRequest, publicApiRequest } from '@/lib/queryClient';
 import { useToast } from '@/hooks/use-toast';
 import { z } from 'zod';
 import { ExternalLink, Mail, Users, Phone, FileText, Info, DollarSign, Pickaxe, Star, Heart, Shield, Plus, Minus, HelpCircle } from 'lucide-react';
@@ -47,11 +47,18 @@ export function SimpleFormModal({ isOpen, onClose, formTemplate, siteId, colorTh
   const config = formTemplate.config || {};
 
   // Fetch the actual form template fields
-  const { data: formFields = [], isLoading, isError, error } = useQuery<any[]>({
-    queryKey: [`/api/form-templates/${formTemplate.id}/fields`],
+  const formFieldsUrl = `/api/form-templates/${formTemplate.id}/fields`;
+  const {
+    data: formFields = [],
+    isLoading,
+    isError,
+    error,
+  } = useQuery<any[]>({
+    queryKey: [formFieldsUrl],
     enabled: !!formTemplate.id && isOpen,
     retry: 2, // Retry failed requests
     retryDelay: 1000, // Wait 1 second between retries
+    queryFn: () => publicApiRequest('GET', formFieldsUrl).then((res) => res.json()),
   });
 
   // Create dynamic form schema based on actual fields - memoized to prevent recreations

--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -23,6 +23,22 @@ export async function apiRequest(
   return res;
 }
 
+export async function publicApiRequest(
+  method: string,
+  url: string,
+  data?: unknown | undefined,
+): Promise<Response> {
+  const res = await fetch(url, {
+    method,
+    headers: data ? { "Content-Type": "application/json" } : {},
+    body: data ? JSON.stringify(data) : undefined,
+    credentials: "omit",
+  });
+
+  await throwIfResNotOk(res);
+  return res;
+}
+
 type UnauthorizedBehavior = "returnNull" | "throw";
 export const getQueryFn: <T>(options: {
   on401: UnauthorizedBehavior;

--- a/client/src/pages/dynamic-site.tsx
+++ b/client/src/pages/dynamic-site.tsx
@@ -18,7 +18,7 @@ import { SiteFooter } from '@/components/site-footer';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
-import { apiRequest } from '@/lib/queryClient';
+import { apiRequest, publicApiRequest } from '@/lib/queryClient';
 import { useToast } from '@/hooks/use-toast';
 import { insertLeadSchema, type InsertLead } from '@shared/schema';
 import { z } from 'zod';
@@ -130,6 +130,7 @@ function DynamicFormModal({ isOpen, onClose, formTemplate, siteId, colorTheme }:
   const config = formTemplate.config || {};
 
   // Fetch the actual form template fields
+  const formFieldsUrl = `/api/form-templates/${formTemplate.id}/fields`;
   const {
     data: formFields = [],
     isLoading,
@@ -137,8 +138,9 @@ function DynamicFormModal({ isOpen, onClose, formTemplate, siteId, colorTheme }:
     error,
     refetch,
   } = useQuery<any[]>({
-    queryKey: [`/api/form-templates/${formTemplate.id}/fields`],
+    queryKey: [formFieldsUrl],
     enabled: !!formTemplate.id && isOpen,
+    queryFn: () => publicApiRequest('GET', formFieldsUrl).then((res) => res.json()),
   });
 
   if (isError) {


### PR DESCRIPTION
## Summary
- add `publicApiRequest` helper that omits credentials
- fetch form fields in `SimpleFormModal` and `DynamicFormModal` via public helper
- document helper usage in `Codex`

## Testing
- `npm test` *(fails: 36 failed, missing Playwright browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc9dcc5d883319fc08a1d97219610