### PR TITLE
docs: add env sample and document environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,34 @@
+# Environment configuration for Mining Syndicate Platform
+# Variables are managed in Replit's Secrets manager in production.
+# Copy this file to .env and fill in values for local development.
+
+# Google OAuth
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+GOOGLE_OAUTH_CALLBACK_URL=http://localhost:5000/api/auth/google/callback
+
+# Database
+DATABASE_URL=
+
+# Session management
+SESSION_SECRET=
+
+# HubSpot
+HUBSPOT_API_KEY=
+
+# Server configuration
+PORT=5000
+BASE_DEV_URL=http://0.0.0.0:5000/api
+BASE_CODEX_URL=https://conduit.replit.app/api
+
+# Object storage
+REPLIT_SIDECAR_ENDPOINT=http://127.0.0.1:1106
+PUBLIC_OBJECT_SEARCH_PATHS=
+PRIVATE_OBJECT_DIR=
+
+# Replit OIDC authentication
+ISSUER_URL=https://replit.com/oidc
+REPL_ID=
+REPLIT_DEV_DOMAIN=conduit.replit.app
+REPLIT_DOMAINS=conduit.replit.app
+

--- a/Codex.md
+++ b/Codex.md
@@ -2,6 +2,7 @@
 
 ## Summary of Recent Changes
 
+- 2025-09-07: added `.env.example` and documented environment variables to improve developer onboarding; all teams must keep the sample file updated when new variables are introduced.
 - Enabled unauthenticated retrieval of form template fields and sanitized the response to expose only public field data, excluding internal attributes like system flags and timestamps.
 - Added a unit test confirming the endpoint’s sanitized output and public accessibility without authentication.
 - Captured `isError` and `error` from the form field query so the modal can detect when loading fails.

--- a/README.md
+++ b/README.md
@@ -26,11 +26,29 @@ Install CodeMirror and its language packages with `npm install` so code snippets
   - Requires `git` and network access to import public repositories.
   - Automatically opens your browser to the explorer page.
 
-Assumptions/Env vars:
+### Environment variables
 
-- `PORT` (optional) – port for both servers (defaults to `5000`).
-- `git` must be available in your PATH for repository cloning.
-- No other environment variables are required for local development.
+Environment configuration is managed through Replit's Secrets manager. For local development, copy `.env.example` to `.env` and provide values. Keep this sample file in sync whenever new variables are introduced.
+
+| Variable | Purpose |
+|----------|---------|
+| `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` | Google OAuth credentials for login. |
+| `GOOGLE_OAUTH_CALLBACK_URL` | Callback URL used by Google during OAuth. |
+| `DATABASE_URL` | Postgres connection string for application data and sessions. |
+| `SESSION_SECRET` | Secret used to sign Express session cookies. |
+| `HUBSPOT_API_KEY` | Token for submitting forms to HubSpot. |
+| `PORT` | Port for the combined Express and Vite servers (defaults to `5000`). |
+| `BASE_DEV_URL` | Local API base URL used during initialization. |
+| `BASE_CODEX_URL` | Fallback Codex API endpoint when the local API is unavailable. |
+| `REPLIT_SIDECAR_ENDPOINT` | Internal endpoint for object storage auth on Replit. |
+| `PUBLIC_OBJECT_SEARCH_PATHS` | Comma-separated object storage paths for public assets. |
+| `PRIVATE_OBJECT_DIR` | Object storage path for private uploads. |
+| `ISSUER_URL` | OIDC issuer for Replit authentication. |
+| `REPL_ID` | Replit workspace identifier required for OIDC. |
+| `REPLIT_DEV_DOMAIN` | Default Replit domain during development. |
+| `REPLIT_DOMAINS` | Comma-separated list of domains allowed for OIDC callbacks. |
+
+`git` must be available in your PATH for repository cloning.
 
 ## Self-Contained Tools
 


### PR DESCRIPTION
## Summary
- add `.env.example` capturing Google, database, session and HubSpot keys
- explain each environment variable in README and call out Replit secrets
- log onboarding update in `Codex.md`

## Testing
- `npm test` *(fails: Playwright browsers missing)*
- `npm run pre-commit`


------
https://chatgpt.com/codex/tasks/task_e_68bdd128da548331be0e40d167b4b079