### PR TITLE
feat: persist hubspot contact ids for site leads

### DIFF
--- a/Codex.md
+++ b/Codex.md
@@ -11,4 +11,6 @@
 - Validated dynamic form fields before schema and default value construction, skipping malformed entries to avoid runtime errors.
 - Introduced `publicApiRequest` helper to fetch form fields without cookies and updated form modals to use it.
 
+- 2025-09-07: persisted HubSpot contact IDs on site leads via new `updateSiteLead` helper for CRM integration consistency; analytics collection remains unchanged, but marketing workflows can now cross-reference local leads with HubSpot contacts.
+
 

--- a/server/site-routes.ts
+++ b/server/site-routes.ts
@@ -328,9 +328,18 @@ export function registerSiteRoutes(app: Express, storage?: any) {
           const result = await hubspotService.createContact(contactData);
           if (result) {
             console.log(`Contact created/updated in HubSpot with ID: ${result.id}`);
-            
             // Update the lead with HubSpot contact ID
-            // TODO: Implement updateSiteLead method if needed
+            try {
+              await siteStorage.updateSiteLead(lead.id, {
+                hubspotContactId: result.id,
+              });
+              console.log(`Lead ${lead.id} updated with HubSpot contact ID ${result.id}`);
+            } catch (updateError) {
+              console.error(
+                "Failed to update lead with HubSpot contact ID:",
+                updateError
+              );
+            }
           }
         } catch (hubspotError) {
           console.error("HubSpot contact creation failed:", hubspotError);

--- a/server/site-storage.ts
+++ b/server/site-storage.ts
@@ -16,6 +16,7 @@ export interface ISiteStorage {
   createSiteLead(lead: InsertSiteLead & { siteId: string }): Promise<SiteLead>;
   getSiteLeads(siteId: string): Promise<SiteLead[]>;
   getSiteLeadsByType(siteId: string, formType: string): Promise<SiteLead[]>;
+  updateSiteLead(leadId: string, updates: Partial<InsertSiteLead>): Promise<SiteLead>;
   
   // Analytics operations
   createSiteAnalytics(analytics: InsertSiteAnalytics & { siteId: string }): Promise<SiteAnalytics>;
@@ -146,6 +147,18 @@ export class DatabaseSiteStorage implements ISiteStorage {
       .from(siteLeads)
       .where(and(eq(siteLeads.siteId, siteId), eq(siteLeads.formType, formType)))
       .orderBy(desc(siteLeads.createdAt));
+  }
+
+  async updateSiteLead(leadId: string, updates: Partial<InsertSiteLead>): Promise<SiteLead> {
+    const [lead] = await db
+      .update(siteLeads)
+      .set({
+        ...updates,
+        updatedAt: new Date(),
+      })
+      .where(eq(siteLeads.id, leadId))
+      .returning();
+    return lead;
   }
 
   // Analytics operations


### PR DESCRIPTION
## Summary
- add updateSiteLead helper to storage layer to persist external HubSpot contact IDs
- update site lead submission route to store HubSpot contact ID with logging
- document CRM integration consistency in Codex

## Testing
- `npm test` (fails: browserType.launch executable doesn't exist)
- `npm run check` (fails: type errors in server/site-storage.ts and related files)


------
https://chatgpt.com/codex/tasks/task_e_68bdd46b9e588331aefbec83896d579b