### PR TITLE
feat: respect site language in forms

### DIFF
--- a/Codex.md
+++ b/Codex.md
@@ -2,6 +2,7 @@
 
 ## Summary of Recent Changes
 
+- 2025-09-07: resolved form field language from each site's configuration, updating dynamic and simple form modals to honor translations with graceful English fallbacks; improves localized UX across sites.
 - 2025-09-07: added `.env.example` and documented environment variables to improve developer onboarding; all teams must keep the sample file updated when new variables are introduced.
 - Enabled unauthenticated retrieval of form template fields and sanitized the response to expose only public field data, excluding internal attributes like system flags and timestamps.
 - Added a unit test confirming the endpoint’s sanitized output and public accessibility without authentication.

--- a/client/src/components/presentation-viewer.tsx
+++ b/client/src/components/presentation-viewer.tsx
@@ -206,6 +206,7 @@ function DynamicFormsSlide({ forms, siteId, onPrevSlide, onNextSlide }: DynamicF
             formTemplate={selectedFormAssignment.formTemplate}
             siteId={siteId}
             colorTheme={getFormColor(selectedFormAssignment.overrideConfig?.color || selectedFormAssignment.formTemplate.config?.color || 'blue')}
+            selectedLanguage={selectedFormAssignment.selectedLanguage}
           />
         )}
 

--- a/client/src/components/simple-form-modal.tsx
+++ b/client/src/components/simple-form-modal.tsx
@@ -21,6 +21,7 @@ interface DynamicFormModalProps {
   formTemplate: any;
   siteId: string;
   colorTheme?: any;
+  selectedLanguage?: string;
 }
 
 // Helper function for form icons
@@ -40,7 +41,7 @@ const getFormIcon = (iconName: string) => {
   }
 };
 
-export function SimpleFormModal({ isOpen, onClose, formTemplate, siteId, colorTheme }: DynamicFormModalProps) {
+export function SimpleFormModal({ isOpen, onClose, formTemplate, siteId, colorTheme, selectedLanguage = 'en' }: DynamicFormModalProps) {
   const { toast } = useToast();
   const [showSuccess, setShowSuccess] = useState(false);
   
@@ -351,11 +352,10 @@ export function SimpleFormModal({ isOpen, onClose, formTemplate, siteId, colorTh
       return null;
     }
     
-    // Get language from formAssignment or default to 'en'
-    const selectedLanguage = 'en'; // TODO: Get from site form assignment
-    
+    const language = selectedLanguage || 'en';
+
     // Use translations if available, otherwise fall back to default
-    const translation = field.fieldLibrary.translations?.[selectedLanguage];
+    const translation = field.fieldLibrary.translations?.[language];
     const label = field.customLabel || translation?.label || field.fieldLibrary.label || fieldName;
     const placeholder = field.placeholder || translation?.placeholder || field.fieldLibrary.defaultPlaceholder || '';
     const description = translation?.description || field.fieldLibrary.defaultValidation?.description;

--- a/client/src/pages/dynamic-site.tsx
+++ b/client/src/pages/dynamic-site.tsx
@@ -121,9 +121,10 @@ interface DynamicFormModalProps {
   formTemplate: any;
   siteId: string;
   colorTheme?: any;
+  selectedLanguage?: string;
 }
 
-function DynamicFormModal({ isOpen, onClose, formTemplate, siteId, colorTheme }: DynamicFormModalProps) {
+function DynamicFormModal({ isOpen, onClose, formTemplate, siteId, colorTheme, selectedLanguage = 'en' }: DynamicFormModalProps) {
   const { toast } = useToast();
   const [showSuccess, setShowSuccess] = useState(false);
   
@@ -480,12 +481,10 @@ function DynamicFormModal({ isOpen, onClose, formTemplate, siteId, colorTheme }:
   // Dynamic field renderer component
   const renderFormField = (field: any) => {
     const fieldName = field.fieldLibrary.name;
-    
-    // Get language from formAssignment or default to 'en'
-    const selectedLanguage = 'en'; // TODO: Get from site form assignment
-    
+    const language = selectedLanguage || 'en';
+
     // Use translations if available, otherwise fall back to default
-    const translation = field.fieldLibrary.translations?.[selectedLanguage];
+    const translation = field.fieldLibrary.translations?.[language];
     const label = field.customLabel || translation?.label || field.fieldLibrary.label;
     const placeholder = field.placeholder || translation?.placeholder || field.fieldLibrary.defaultPlaceholder || '';
     const description = translation?.description || field.fieldLibrary.defaultValidation?.description;
@@ -1392,6 +1391,7 @@ function PitchSiteInterface({ site, siteId, showPresentation, setShowPresentatio
           formTemplate={selectedFormAssignment.formTemplate}
           siteId={siteId || ''}
           colorTheme={getFormColor(selectedFormAssignment.overrideConfig?.color || selectedFormAssignment.formTemplate.config?.color || 'blue')}
+          selectedLanguage={selectedFormAssignment.selectedLanguage}
         />
       )}
 


### PR DESCRIPTION
## Summary
- use site-level language to select field translations in dynamic and simple form modals
- pass selected language from form assignments to modals
- document localization update in Codex

## Testing
- `npm run test:unit`
- `npm test` *(fails: Executable doesn't exist at /root/.cache/ms-playwright/webkit-2203/pw_run.sh)*
- `npm run check` *(fails: TS errors in server files)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd570afd48331be86dcec21409ca3