### PR TITLE
feat: add internal analytics tracking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,3 +32,6 @@ REPL_ID=
 REPLIT_DEV_DOMAIN=conduit.replit.app
 REPLIT_DOMAINS=conduit.replit.app
 
+# Analytics
+VITE_ANALYTICS_PROVIDER=internal
+

--- a/Codex.md
+++ b/Codex.md
@@ -14,4 +14,6 @@
 
 - 2025-09-07: persisted HubSpot contact IDs on site leads via new `updateSiteLead` helper for CRM integration consistency; analytics collection remains unchanged, but marketing workflows can now cross-reference local leads with HubSpot contacts.
 
+- 2025-09-07: enabled internal analytics tracking via `/api/sites/:siteId/analytics` with client-side consent checks. Set `VITE_ANALYTICS_PROVIDER` (default `internal`) for deployments; Replit and Card-Builder teams must ensure this variable is configured and respect `analytics-consent` localStorage before collecting events.
+
 


### PR DESCRIPTION
## Summary
- add configurable internal analytics provider with consent checks
- expose /api/sites/:siteId/analytics endpoint and client tracking
- document analytics config in Codex and env example

## Testing
- `npm test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/webkit-2203/pw_run.sh)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd6af68cc83318b519dcd122998e0