### PR TITLE
feat: add TaskRepo interface and generators hooks

### DIFF
--- a/Codex.md
+++ b/Codex.md
@@ -15,5 +15,4 @@
 - 2025-09-07: persisted HubSpot contact IDs on site leads via new `updateSiteLead` helper for CRM integration consistency; analytics collection remains unchanged, but marketing workflows can now cross-reference local leads with HubSpot contacts.
 
 - 2025-09-07: enabled internal analytics tracking via `/api/sites/:siteId/analytics` with client-side consent checks. Set `VITE_ANALYTICS_PROVIDER` (default `internal`) for deployments; Replit and Card-Builder teams must ensure this variable is configured and respect `analytics-consent` localStorage before collecting events.
-
-
+- 2025-09-07: introduced a `TaskRepo` interface and Express stub generator that delegates task creation to injected repositories. Code-Explorer should supply a `SnowflakeTaskRepo` that calls stored procedures, while Card-Builder can use the provided `InMemoryTaskRepo` for local tests before swapping in a Snowflake-backed repo.

--- a/client/src/lib/generators.ts
+++ b/client/src/lib/generators.ts
@@ -1,4 +1,5 @@
 import { CreateTaskInput } from "../../shared/schema";
+export type { TaskRepo } from "../../shared/taskRepo";
 
 export function downloadText(filename: string, content: string) {
   const blob = new Blob([content], { type: "text/plain;charset=utf-8" });
@@ -20,21 +21,24 @@ export const ${constName}: CreateTaskInput = ${JSON.stringify(task, null, 2)} as
 export function genExpressStub(route: string) {
   return `// Auto-generated minimal Express route stub
 import { Router } from "express";
-const r = Router();
+import type { TaskRepo } from "./taskRepo";
 
-// TODO: wire to Snowflake procs or your TaskRepo
-r.post("${'${route}'}", async (req, res) => {
-  try {
-    // const input = req.body; validate if needed
-    // const result = await TaskRepo.create(input);
-    res.status(201).json({ ok: true /*, result */ });
-  } catch (e) {
-    console.error(e);
-    res.status(500).json({ error: "failed" });
-  }
-});
+export default function makeRoute(repo: TaskRepo) {
+  const r = Router();
 
-export default r;
+  r.post("${route}", async (req, res) => {
+    try {
+      // const input = req.body; validate if needed
+      const result = await repo.create(req.body);
+      res.status(201).json({ ok: true, result });
+    } catch (e) {
+      console.error(e);
+      res.status(500).json({ error: "failed" });
+    }
+  });
+
+  return r;
+}
 `;
 }
 

--- a/server/taskRepo.ts
+++ b/server/taskRepo.ts
@@ -1,0 +1,29 @@
+import { CreateTaskInput } from "../shared/schema";
+import { TaskRepo } from "../shared/taskRepo";
+
+export class SnowflakeTaskRepo implements TaskRepo {
+  constructor(private conn: any, private procName: string) {}
+
+  async create(input: CreateTaskInput): Promise<unknown> {
+    return await new Promise((resolve, reject) => {
+      this.conn.execute({
+        sqlText: `call ${this.procName}(?)`,
+        binds: [JSON.stringify(input)],
+        complete(err: any, _stmt: any, rows: unknown[]) {
+          if (err) reject(err);
+          else resolve(rows);
+        },
+      });
+    });
+  }
+}
+
+export class InMemoryTaskRepo implements TaskRepo {
+  private data: CreateTaskInput[] = [];
+
+  async create(input: CreateTaskInput): Promise<unknown> {
+    this.data.push(input);
+    return input;
+  }
+}
+

--- a/shared/taskRepo.ts
+++ b/shared/taskRepo.ts
@@ -1,0 +1,6 @@
+import { CreateTaskInput } from "./schema";
+
+export interface TaskRepo {
+  create(input: CreateTaskInput): Promise<unknown>;
+}
+


### PR DESCRIPTION
## Summary
- add shared `TaskRepo` interface for task creation
- wire Express route generator to injected `TaskRepo`
- provide Snowflake and in-memory `TaskRepo` examples
- document integration points in `Codex.md`

## Testing
- `npm test` *(fails: Playwright browsers missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd831b2d483318ac9281dd13092b1