### PR TITLE
Add GitHub Actions CI and enforce status checks

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,9 @@
+# Repository settings managed through configuration as code
+# Enforces status checks so failing builds block merges
+branches:
+  - name: main
+    protection:
+      required_status_checks:
+        strict: true
+        contexts:
+          - CI

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18.x, 20.x]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+      - run: npm ci
+      - run: npm test
+      - run: npm run build

--- a/Codex.md
+++ b/Codex.md
@@ -4,6 +4,7 @@
 
 ## Summary of Recent Changes
 
+2025-09-07: Introduced GitHub Actions CI with caching – automate tests and builds to gate merges – Replit, Code-Explorer, and Card-Builder gain faster feedback and protected main branch.
 2025-09-07: Honored site-specific form field translations – ensure forms reflect language configuration with fallbacks – improved localized UX across sites.
 2025-09-07: Added `.env.example` documenting environment variables – guide onboarding and track required variables – teams maintain sample file to stay synced.
 2025-09-07: Exposed public form fields via unauthenticated API – avoid leaking internal metadata – external consumers retrieve only safe fields.


### PR DESCRIPTION
## Summary
- add CI workflow that installs dependencies, runs tests, and builds the project
- require CI to pass on `main` via branch protection settings
- document CI benefits for Replit, Code-Explorer, and Card-Builder teams

## Testing
- `npm test` *(fails: 36 failed)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bdda6a74888331b92e1c40f7169310