### PR TITLE
refactor: add site lead update helper

### DIFF
--- a/Codex.md
+++ b/Codex.md
@@ -14,6 +14,6 @@
 2025-09-07: Memoized dynamic schema and default value calculations with `useMemo` – reduce redundant computations – improved performance for dynamic fields.
 2025-09-07: Validated dynamic form fields before schema and default value construction – skip malformed entries – avoid runtime errors from invalid definitions.
 2025-09-07: Introduced `publicApiRequest` helper for cookie-free field fetches – support unauthenticated retrieval – consistent public API usage in modals.
-2025-09-07: Persisted HubSpot contact IDs on site leads via `updateSiteLead` – align CRM integration – marketing can cross-reference leads with HubSpot.
+2025-09-07: Persisted HubSpot contact IDs on site leads via `updateSiteLead` – CRM ID persistence – marketing analytics can cross-reference leads with HubSpot.
 2025-09-07: Enabled internal analytics tracking with consent checks – centralize event logging while respecting user consent – Replit and Card-Builder must configure `VITE_ANALYTICS_PROVIDER` before collecting analytics.
 2025-09-07: Added `TaskRepo` interface and Express stub generator – decouple task creation and allow repo injection – teams can swap in Snowflake or in-memory implementations as needed.

--- a/server/__tests__/updateSiteLead.test.ts
+++ b/server/__tests__/updateSiteLead.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../db', () => ({ db: {} }));
+
+import { updateSiteLead, siteStorage } from '../site-storage';
+
+describe('updateSiteLead helper', () => {
+  it('persists the HubSpot ID', async () => {
+    const mockResponse = { id: 'lead1', hubspotContactId: 'hs123' } as any;
+    const spy = vi
+      .spyOn(siteStorage, 'updateSiteLead')
+      .mockResolvedValue(mockResponse);
+    const result = await updateSiteLead('lead1', 'hs123');
+    expect(spy).toHaveBeenCalledWith('lead1', { hubspotContactId: 'hs123' });
+    expect(result).toBe(mockResponse);
+  });
+
+  it('propagates errors from siteStorage', async () => {
+    const error = new Error('db down');
+    vi.spyOn(siteStorage, 'updateSiteLead').mockRejectedValue(error);
+    await expect(updateSiteLead('lead1', 'hs123')).rejects.toThrow(error);
+  });
+});

--- a/server/site-routes.ts
+++ b/server/site-routes.ts
@@ -1,7 +1,7 @@
 import type { Express, Response } from "express";
 import express from "express";
 import path from "path";
-import { siteStorage } from "./site-storage";
+import { siteStorage, updateSiteLead } from "./site-storage";
 import { storage } from "./storage";
 import { qrGenerator } from "./qr-generator";
 import { submitToHubSpotForm } from "./hubspot";
@@ -330,9 +330,7 @@ export function registerSiteRoutes(app: Express, storage?: any) {
             console.log(`Contact created/updated in HubSpot with ID: ${result.id}`);
             // Update the lead with HubSpot contact ID
             try {
-              await siteStorage.updateSiteLead(lead.id, {
-                hubspotContactId: result.id,
-              });
+              await updateSiteLead(lead.id, result.id);
               console.log(`Lead ${lead.id} updated with HubSpot contact ID ${result.id}`);
             } catch (updateError) {
               console.error(

--- a/server/site-storage.ts
+++ b/server/site-storage.ts
@@ -1134,3 +1134,10 @@ export class DatabaseSiteStorage implements ISiteStorage {
 }
 
 export const siteStorage = new DatabaseSiteStorage();
+
+export async function updateSiteLead(
+  leadId: string,
+  hubspotContactId: string
+) {
+  return siteStorage.updateSiteLead(leadId, { hubspotContactId });
+}


### PR DESCRIPTION
## Summary
- wrap `siteStorage.updateSiteLead` in `updateSiteLead`
- use helper in site routes
- test HubSpot ID persistence and error propagation

## Testing
- `npm run test:unit`
- `npx vitest run --root . server/__tests__/updateSiteLead.test.ts`
- `npm run test:playwright` *(fails: CodeExplorer tests)*
- `npm run check` *(fails: type errors in server/storage)*

------
https://chatgpt.com/codex/tasks/task_e_68bddfb83cd48331a85ffee0d5742e9f