### PR TITLE
test: add form and consent e2e coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,5 +18,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
       - run: npm ci
+      - run: npx playwright install --with-deps
       - run: npm test
       - run: npm run build

--- a/Codex.md
+++ b/Codex.md
@@ -4,6 +4,7 @@
 
 ## Summary of Recent Changes
 
+2025-09-09: Added Playwright end-to-end tests for form submission, error handling, analytics consent, and translations – expand coverage to success, network failure, malformed data, and consent flows – increases confidence for Code-Explorer and Card-Builder releases.
 2025-09-08: Localized form modals using site language – fetch preferred language and translate labels, placeholders, and validation errors – non-English users see correct text; Replit must supply translations for new locales.
 2025-09-07: Introduced GitHub Actions CI with caching – automate tests and builds to gate merges – Replit, Code-Explorer, and Card-Builder gain faster feedback and protected main branch.
 2025-09-07: Honored site-specific form field translations – ensure forms reflect language configuration with fallbacks – improved localized UX across sites.

--- a/packages/code-explorer/e2e/analytics-consent.spec.tsx
+++ b/packages/code-explorer/e2e/analytics-consent.spec.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { test, expect } from '@playwright/experimental-ct-react';
+import { useAnalyticsConsent } from '@/components/analytics-consent-modal';
+
+function ConsentTester() {
+  const { ConsentModal } = useAnalyticsConsent();
+  return <ConsentModal />;
+}
+
+test.describe('Analytics consent', () => {
+  test('records consent when allowed', async ({ mount, page }) => {
+    await page.evaluate(() => localStorage.removeItem('analytics-consent'));
+    await mount(<ConsentTester />);
+    await expect(page.getByText('Allow analytics?')).toBeVisible();
+    await page.getByRole('button', { name: 'Allow' }).click();
+    await expect(page.getByText('Allow analytics?')).toBeHidden();
+    const stored = await page.evaluate(() => localStorage.getItem('analytics-consent'));
+    expect(stored).toContain('granted');
+  });
+});

--- a/packages/code-explorer/e2e/simple-form-modal.spec.tsx
+++ b/packages/code-explorer/e2e/simple-form-modal.spec.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { test, expect } from '@playwright/experimental-ct-react';
+import { SimpleFormModal } from '@/components/simple-form-modal';
+
+const formTemplate = { id: 't1', name: 'Test', config: { buttonText: 'Submit' } };
+const formFields = [
+  {
+    id: '1',
+    order: '1',
+    isRequired: true,
+    fieldLibrary: {
+      name: 'email',
+      dataType: 'email',
+      label: 'Email',
+      defaultPlaceholder: 'email@example.com',
+      translations: {
+        es: { label: 'Correo Electrónico', placeholder: 'tu@ejemplo.com' },
+      },
+      defaultValidation: {},
+    },
+  },
+];
+
+test.describe('SimpleFormModal', () => {
+  test('submits form successfully', async ({ mount, page }) => {
+    await page.route('**/api/form-templates/t1/fields', route =>
+      route.fulfill({ status: 200, body: JSON.stringify(formFields) })
+    );
+    await page.route('**/api/sites/site1/leads', route =>
+      route.fulfill({ status: 200, body: '{}' })
+    );
+
+    await mount(
+      <SimpleFormModal
+        isOpen={true}
+        onClose={() => {}}
+        formTemplate={formTemplate}
+        siteId="site1"
+        selectedLanguage="es"
+      />
+    );
+
+    await expect(page.getByLabel('Correo Electrónico')).toBeVisible();
+    await page.fill('[data-testid="input-email"]', 'tu@ejemplo.com');
+    await page.getByRole('button', { name: 'Submit' }).click();
+    await expect(page.getByText('Thank You!')).toBeVisible();
+  });
+
+  test('handles network failure', async ({ mount, page }) => {
+    await page.route('**/api/form-templates/t1/fields', route =>
+      route.fulfill({ status: 200, body: JSON.stringify(formFields) })
+    );
+    await page.route('**/api/sites/site1/leads', route =>
+      route.fulfill({ status: 500, body: 'error' })
+    );
+
+    await mount(
+      <SimpleFormModal
+        isOpen={true}
+        onClose={() => {}}
+        formTemplate={formTemplate}
+        siteId="site1"
+      />
+    );
+
+    await page.fill('[data-testid="input-email"]', 'test@example.com');
+    await page.getByRole('button', { name: 'Submit' }).click();
+    await expect(page.getByText('Submission Failed')).toBeVisible();
+  });
+
+  test('handles malformed field data', async ({ mount, page }) => {
+    await page.route('**/api/form-templates/t1/fields', route =>
+      route.fulfill({ status: 200, body: 'not-json' })
+    );
+
+    await mount(
+      <SimpleFormModal
+        isOpen={true}
+        onClose={() => {}}
+        formTemplate={formTemplate}
+        siteId="site1"
+      />
+    );
+
+    await expect(page.getByText('Failed to load form fields')).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- add Playwright tests for form submission flows and analytics consent
- run Playwright browser install in CI
- document expanded e2e coverage in Codex

## Testing
- `npx playwright install --with-deps` *(fails: Domain forbidden)*
- `npm test` *(failed: 10 did not run)*
- `npx vitest run --root packages/code-explorer` *(failed: useTheme must be used within a ThemeProvider)*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68bde7084f0483318db49f7895ce97d3