### PR TITLE
Document Playwright install issues

### DIFF
--- a/Codex.md
+++ b/Codex.md
@@ -4,6 +4,7 @@
 
 ## Summary of Recent Changes
 
+2025-09-07: Documented Playwright browser downloads blocked and missing libs – cdn.playwright.dev returns 403 "Domain forbidden" and system packages like libatk1.0-0 are absent – E2E tests cannot run until network access and dependencies are installed.
 2025-09-09: Added Playwright end-to-end tests for form submission, error handling, analytics consent, and translations – expand coverage to success, network failure, malformed data, and consent flows – increases confidence for Code-Explorer and Card-Builder releases.
 2025-09-08: Localized form modals using site language – fetch preferred language and translate labels, placeholders, and validation errors – non-English users see correct text; Replit must supply translations for new locales.
 2025-09-07: Introduced GitHub Actions CI with caching – automate tests and builds to gate merges – Replit, Code-Explorer, and Card-Builder gain faster feedback and protected main branch.


### PR DESCRIPTION
## Summary
- note Playwright browser downloads failing with 403 and missing system libraries

## Testing
- `npm test` *(fails: host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68bdec4f28c48331902bb144db026c65