### PR TITLE
feat: add test database url variant

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,11 @@ GOOGLE_CLIENT_SECRET=
 GOOGLE_OAUTH_CALLBACK_URL=http://localhost:5000/api/auth/google/callback
 
 # Database
+# Set `DATABASE_URL` to your primary Postgres instance.
+# `TEST_DATABASE_URL` isolates test runs using a local or in-memory database
+# such as `sqlite::memory:` or a Dockerized Postgres URL.
 DATABASE_URL=
+TEST_DATABASE_URL=
 
 # Session management
 SESSION_SECRET=

--- a/Codex.md
+++ b/Codex.md
@@ -23,3 +23,4 @@
 2025-09-07: Added form refresh controls and offline safeguards – allow refetching form fields and block submissions while offline – Replit must display the new refresh button and offline warnings in modals.
 2025-09-07: Added `TaskRepo` interface and Express stub generator – decouple task creation and allow repo injection – teams can swap in Snowflake or in-memory implementations as needed.
 2025-09-07: Deployed analytics consent modal with timestamped storage and server validation – capture explicit user permission before logging – Replit and Card-Builder pipelines only ingest opted-in data.
+2025-09-07: Added `TEST_DATABASE_URL` for test database isolation – avoid cross-environment data pollution – Playwright tests run against ephemeral databases.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Environment configuration is managed through Replit's Secrets manager. For local
 | `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` | Google OAuth credentials for login. |
 | `GOOGLE_OAUTH_CALLBACK_URL` | Callback URL used by Google during OAuth. |
 | `DATABASE_URL` | Postgres connection string for application data and sessions. |
+| `TEST_DATABASE_URL` | Overrides `DATABASE_URL` during tests for an isolated database. |
 | `SESSION_SECRET` | Secret used to sign Express session cookies. |
 | `HUBSPOT_API_KEY` | Token for submitting forms to HubSpot. |
 | `PORT` | Port for the combined Express and Vite servers (defaults to `5000`). |
@@ -49,6 +50,12 @@ Environment configuration is managed through Replit's Secrets manager. For local
 | `REPL_ID` | Replit workspace identifier required for OIDC. |
 | `REPLIT_DEV_DOMAIN` | Default Replit domain during development. |
 | `REPLIT_DOMAINS` | Comma-separated list of domains allowed for OIDC callbacks. |
+
+
+Switch between remote and local databases by editing `.env`:
+
+- Set `DATABASE_URL` to your remote Postgres instance.
+- Define `TEST_DATABASE_URL` for local or in-memory databases when running tests. When present, test runners use this value, keeping test data isolated from the remote database.
 
 `git` must be available in your PATH for repository cloning.
 

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig } from "drizzle-kit";
 
-if (!process.env.DATABASE_URL) {
+const connectionString = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
+
+if (!connectionString) {
   throw new Error("DATABASE_URL, ensure the database is provisioned");
 }
 
@@ -9,6 +11,6 @@ export default defineConfig({
   schema: "./shared/schema.ts",
   dialect: "postgresql",
   dbCredentials: {
-    url: process.env.DATABASE_URL,
+    url: connectionString,
   },
 });

--- a/server/db.ts
+++ b/server/db.ts
@@ -6,11 +6,16 @@ import * as siteSchema from "@shared/site-schema";
 
 neonConfig.webSocketConstructor = ws;
 
-if (!process.env.DATABASE_URL) {
+const connectionString =
+  process.env.NODE_ENV === "test"
+    ? process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL
+    : process.env.DATABASE_URL;
+
+if (!connectionString) {
   throw new Error(
     "DATABASE_URL must be set. Did you forget to provision a database?",
   );
 }
 
-export const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+export const pool = new Pool({ connectionString });
 export const db = drizzle({ client: pool, schema: { ...schema, ...siteSchema } });

--- a/server/google-auth.ts
+++ b/server/google-auth.ts
@@ -34,7 +34,10 @@ export function getSession() {
   const sessionTtl = 7 * 24 * 60 * 60 * 1000; // 1 week
   const pgStore = connectPg(session);
   const sessionStore = new pgStore({
-    conString: process.env.DATABASE_URL,
+    conString:
+      process.env.NODE_ENV === "test"
+        ? process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL
+        : process.env.DATABASE_URL,
     createTableIfMissing: true,
     ttl: sessionTtl,
     tableName: "sessions",

--- a/server/replit-auth.ts
+++ b/server/replit-auth.ts
@@ -34,7 +34,10 @@ export function getSession() {
   const sessionTtl = 7 * 24 * 60 * 60 * 1000; // 1 week
   const pgStore = connectPg(session);
   const sessionStore = new pgStore({
-    conString: process.env.DATABASE_URL,
+    conString:
+      process.env.NODE_ENV === "test"
+        ? process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL
+        : process.env.DATABASE_URL,
     createTableIfMissing: true,
     ttl: sessionTtl,
     tableName: "sessions",


### PR DESCRIPTION
## Summary
- allow TEST_DATABASE_URL to override database connection for tests
- document switching between remote and local databases via `.env`
- note isolation benefits for Playwright tests in Codex

## Testing
- `npm test` *(fails: Executable doesn't exist... instructs to run `npx playwright install`)*
- `npx playwright install` *(fails: server returned code 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf4a7aeec8331aa443eb25cd7f8ba