### PR TITLE
docs: add mock auth quick start instructions

### DIFF
--- a/Codex.md
+++ b/Codex.md
@@ -6,6 +6,8 @@
 
 2025-09-09: Added AUTH_DISABLED flag for mock sessions – support local development without OAuth – developers can bypass login.
 
+2025-09-07: Documented mock-auth onboarding steps – clarify .env setup and auth toggle – developers start locally faster.
+
 2025-09-07: Installed Playwright browsers and system packages after npm install – ensure tests run locally and in CI – developers get a consistent E2E environment.
 2025-09-07: Documented Playwright browser downloads blocked and missing libs – cdn.playwright.dev returns 403 "Domain forbidden" and system packages like libatk1.0-0 are absent – E2E tests cannot run until network access and dependencies are installed.
 2025-09-09: Added Playwright end-to-end tests for form submission, error handling, analytics consent, and translations – expand coverage to success, network failure, malformed data, and consent flows – increases confidence for Code-Explorer and Card-Builder releases.

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -25,6 +25,26 @@ This guide covers setting up the project locally, running tests, and establishin
    ```
    Visit `http://localhost:5000` to view the app.
 
+## Quick start with mock auth
+
+1. Copy the example environment file.
+   ```bash
+   cp .env.example .env
+   ```
+2. Set `AUTH_DISABLED=true` in `.env` to bypass OAuth.
+3. Start your local database if the app uses one.
+4. Run the development server.
+   ```bash
+   npm run dev
+   ```
+
+### Switch to the full auth flow
+
+1. Stop the server.
+2. Remove `AUTH_DISABLED` or set it to `false`.
+3. Add the required auth variables to `.env`.
+4. Restart the server to sign in with OAuth.
+
 ## Running Tests
 
 - **Full test suite**


### PR DESCRIPTION
## Summary
- document quick start for disabling auth with AUTH_DISABLED
- note how to re-enable full authentication
- record documentation update in Codex

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdf81897ec83318f4c5d56ced0fd03