### PR TITLE
docs: require Postgres connection URIs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,9 +11,8 @@ GOOGLE_OAUTH_CALLBACK_URL=http://localhost:5000/api/auth/google/callback
 AUTH_DISABLED=false
 
 # Database
-# Set `DATABASE_URL` to your primary Postgres instance.
-# `TEST_DATABASE_URL` isolates test runs using a local or in-memory database
-# such as `sqlite::memory:` or a Dockerized Postgres URL.
+# Set `DATABASE_URL` to your primary Postgres instance (e.g., `postgres://user:pass@localhost:5432/db`).
+# `TEST_DATABASE_URL` isolates test runs using a separate Postgres database (e.g., `postgres://user:pass@localhost:5432/testdb`).
 DATABASE_URL=
 TEST_DATABASE_URL=
 

--- a/Codex.md
+++ b/Codex.md
@@ -4,6 +4,7 @@
 
 ## Summary of Recent Changes
 
+2025-09-07: Removed sqlite references and documented Postgres URI requirements – clarify mandatory Postgres backend – prevents misconfiguration with unsupported databases.
 2025-09-09: Added AUTH_DISABLED flag for mock sessions – support local development without OAuth – developers can bypass login.
 
 2025-09-07: Documented mock-auth onboarding steps – clarify .env setup and auth toggle – developers start locally faster.

--- a/README.md
+++ b/README.md
@@ -30,14 +30,14 @@ Required packages include `libnss3`, `libatk-1.0-0`, and `fonts-liberation`.
 
 ### Environment variables
 
-Environment configuration is managed through Replit's Secrets manager. For local development, copy `.env.example` to `.env` and provide values. Keep this sample file in sync whenever new variables are introduced.
+Environment configuration is managed through Replit's Secrets manager. For local development, copy `.env.example` to `.env` and provide values. Keep this sample file in sync whenever new variables are introduced. Database URLs must use the standard Postgres URI format (e.g., `postgres://user:pass@localhost:5432/db`).
 
 | Variable | Purpose |
 |----------|---------|
 | `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` | Google OAuth credentials for login. |
 | `GOOGLE_OAUTH_CALLBACK_URL` | Callback URL used by Google during OAuth. |
 | `DATABASE_URL` | Postgres connection string for application data and sessions. |
-| `TEST_DATABASE_URL` | Overrides `DATABASE_URL` during tests for an isolated database. |
+| `TEST_DATABASE_URL` | Overrides `DATABASE_URL` during tests for a separate Postgres database. |
 | `SESSION_SECRET` | Secret used to sign Express session cookies. |
 | `HUBSPOT_API_KEY` | Token for submitting forms to HubSpot. |
 | `AUTH_DISABLED` | Set to `true` to bypass authentication with a mock admin user. |
@@ -53,10 +53,10 @@ Environment configuration is managed through Replit's Secrets manager. For local
 | `REPLIT_DOMAINS` | Comma-separated list of domains allowed for OIDC callbacks. |
 
 
-Switch between remote and local databases by editing `.env`:
+Switch between Postgres databases by editing `.env`:
 
-- Set `DATABASE_URL` to your remote Postgres instance.
-- Define `TEST_DATABASE_URL` for local or in-memory databases when running tests. When present, test runners use this value, keeping test data isolated from the remote database.
+- Set `DATABASE_URL` to your primary Postgres instance.
+- Define `TEST_DATABASE_URL` for a dedicated test Postgres database (e.g., `postgres://user:pass@localhost:5432/testdb`). When present, test runners use this value, keeping test data isolated from the remote database.
 
 `git` must be available in your PATH for repository cloning.
 


### PR DESCRIPTION
## Summary
- clarify Postgres requirement in environment sample and README
- document expected `postgres://` URI format
- log change and rationale in Codex

## Testing
- `npm test` *(fails: 1 interrupted; 8 did not run)*

------
https://chatgpt.com/codex/tasks/task_e_68bdfd51ac508331b21583238e561ccf