### PR TITLE
chore: add dockerized Postgres for local testing

### DIFF
--- a/Codex.md
+++ b/Codex.md
@@ -4,6 +4,7 @@
 
 ## Summary of Recent Changes
 
+2025-09-07: Added dockerized Postgres with db:up/down scripts – standardize local DB setup – enables cross-team isolated testing.
 2025-09-07: Removed sqlite references and documented Postgres URI requirements – clarify mandatory Postgres backend – prevents misconfiguration with unsupported databases.
 2025-09-09: Added AUTH_DISABLED flag for mock sessions – support local development without OAuth – developers can bypass login.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.9'
+services:
+  postgres:
+    image: postgres:16
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: postgres
+    ports:
+      - '5432:5432'
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+volumes:
+  postgres_data:

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -19,11 +19,16 @@ This guide covers setting up the project locally, running tests, and establishin
    ```
    Required packages include `libnss3`, `libatk-1.0-0`, and `fonts-liberation`.
    > **Note:** A `403 Domain forbidden` error during `npx playwright install` usually means the CDN is blocked or requires credentials, while `403`s during test execution typically come from anti-bot measures on the target website.
-4. **Start the development servers**
+4. **Start the database**
+   ```bash
+   npm run db:up
+   ```
+   Uses port `5432`. Run `npm run db:down` to stop it.
+5. **Start the development servers**
    ```bash
    npm run dev
    ```
-   Visit `http://localhost:5000` to view the app.
+   Runs on port `5000`. Visit `http://localhost:5000` to view the app.
 
 ## Quick start with mock auth
 
@@ -32,7 +37,11 @@ This guide covers setting up the project locally, running tests, and establishin
    cp .env.example .env
    ```
 2. Set `AUTH_DISABLED=true` in `.env` to bypass OAuth.
-3. Start your local database if the app uses one.
+3. Start the local Postgres service.
+   ```bash
+   npm run db:up
+   ```
+   Uses port `5432`. Stop with `npm run db:down` when finished.
 4. Run the development server.
    ```bash
    npm run dev

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "test:unit": "vitest run && vitest run packages/card-builder/src/__tests__/config.test.ts packages/card-builder/src/__tests__/export-assets.test.ts --dir packages/card-builder",
     "test:playwright": "playwright test",
     "db:push": "drizzle-kit push",
+    "db:up": "docker compose up -d",
+    "db:down": "docker compose down",
     "pre-commit": "node scripts/check-persona-updates.js"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- add docker-compose with Postgres
- add db:up/db:down npm scripts
- update onboarding docs for database instructions and ports
- log cross-team testing benefits in Codex

## Testing
- `npm run db:up` (fails: docker not found)
- `npm run db:down` (fails: docker not found)
- `npm test` (Playwright tests incomplete; 20 did not run)
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68bdffd0088483319a662e7792220f2a