### PR TITLE
chore: add db migrate script and update onboarding docs

### DIFF
--- a/Codex.md
+++ b/Codex.md
@@ -4,6 +4,7 @@
 
 ## Summary of Recent Changes
 
+2025-09-07: Added db:migrate script and test-aware drizzle config – streamline schema updates across environments – teams run migrations consistently without polluting production data.
 2025-09-07: Added dockerized Postgres with db:up/down scripts – standardize local DB setup – enables cross-team isolated testing.
 2025-09-07: Removed sqlite references and documented Postgres URI requirements – clarify mandatory Postgres backend – prevents misconfiguration with unsupported databases.
 2025-09-09: Added AUTH_DISABLED flag for mock sessions – support local development without OAuth – developers can bypass login.

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -22,6 +22,7 @@ This guide covers setting up the project locally, running tests, and establishin
 4. **Start the database**
    ```bash
    npm run db:up
+   npm run db:migrate
    ```
    Uses port `5432`. Run `npm run db:down` to stop it.
 5. **Start the development servers**
@@ -40,6 +41,7 @@ This guide covers setting up the project locally, running tests, and establishin
 3. Start the local Postgres service.
    ```bash
    npm run db:up
+   npm run db:migrate
    ```
    Uses port `5432`. Stop with `npm run db:down` when finished.
 4. Run the development server.

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,6 +1,9 @@
 import { defineConfig } from "drizzle-kit";
 
-const connectionString = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
+const connectionString =
+  process.env.NODE_ENV === "test"
+    ? process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL
+    : process.env.DATABASE_URL;
 
 if (!connectionString) {
   throw new Error("DATABASE_URL, ensure the database is provisioned");

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test:unit": "vitest run && vitest run packages/card-builder/src/__tests__/config.test.ts packages/card-builder/src/__tests__/export-assets.test.ts --dir packages/card-builder",
     "test:playwright": "playwright test",
     "db:push": "drizzle-kit push",
+    "db:migrate": "drizzle-kit push",
     "db:up": "docker compose up -d",
     "db:down": "docker compose down",
     "pre-commit": "node scripts/check-persona-updates.js"


### PR DESCRIPTION
## Summary
- add `db:migrate` script to push database schema
- make drizzle config pick `TEST_DATABASE_URL` when `NODE_ENV=test`
- document running migrations after bringing up the database

## Testing
- `npm test` *(fails: 48 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68be012f5da083318d349a2d823f8a59