### PR TITLE
feat: use pg driver for local database urls

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,7 @@ AUTH_DISABLED=false
 
 # Database
 # Set `DATABASE_URL` to your primary Postgres instance (e.g., `postgres://user:pass@localhost:5432/db`).
+# URLs with `localhost` or `127.0.0.1` use the local `pg` driver; other hosts default to Neon.
 # `TEST_DATABASE_URL` isolates test runs using a separate Postgres database (e.g., `postgres://user:pass@localhost:5432/testdb`).
 DATABASE_URL=
 TEST_DATABASE_URL=

--- a/Codex.md
+++ b/Codex.md
@@ -4,6 +4,8 @@
 
 ## Summary of Recent Changes
 
+2025-09-07: Switched database driver based on URL host – local DB support – enables all teams to run against local Postgres without Neon.
+
 2025-09-07: Added db:migrate script and test-aware drizzle config – streamline schema updates across environments – teams run migrations consistently without polluting production data.
 2025-09-07: Added dockerized Postgres with db:up/down scripts – standardize local DB setup – enables cross-team isolated testing.
 2025-09-07: Removed sqlite references and documented Postgres URI requirements – clarify mandatory Postgres backend – prevents misconfiguration with unsupported databases.


### PR DESCRIPTION
## Summary
- switch db.ts to detect localhost URLs and use the pg driver
- keep Neon-based client for remote connections
- document driver switching and log change in Codex

## Testing
- `npm test` *(fails: Failed to load url supertest)*
- `npm run check` *(fails: multiple TS errors in server and shared modules)*
- `npm run pre-commit`


------
https://chatgpt.com/codex/tasks/task_e_68be069834a483319180d868631037d1