### PR TITLE
feat: add database seeding script

### DIFF
--- a/Codex.md
+++ b/Codex.md
@@ -34,3 +34,4 @@
 2025-09-07: Deployed analytics consent modal with timestamped storage and server validation – capture explicit user permission before logging – Replit and Card-Builder pipelines only ingest opted-in data.
 2025-09-07: Added `TEST_DATABASE_URL` for test database isolation – avoid cross-environment data pollution – Playwright tests run against ephemeral databases.
 2025-09-07: Added API health test using AUTH_DISABLED with test DB – verifies server starts and connects to database – boosts confidence for all teams.
+2025-09-07: Added scriptable DB seeding – populate baseline data from JSON – developers initialize databases in one command.

--- a/README.md
+++ b/README.md
@@ -58,6 +58,16 @@ Switch between Postgres databases by editing `.env`:
 - Set `DATABASE_URL` to your primary Postgres instance.
 - Define `TEST_DATABASE_URL` for a dedicated test Postgres database (e.g., `postgres://user:pass@localhost:5432/testdb`). When present, test runners use this value, keeping test data isolated from the remote database.
 
+### Database migrations and seeds
+
+Run migrations and load baseline data with:
+
+```
+npm run db:seed
+```
+
+This command applies pending schema changes and inserts records from `server/seeds/`.
+
 `git` must be available in your PATH for repository cloning.
 
 ## Self-Contained Tools

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:playwright": "playwright test",
     "db:push": "drizzle-kit push",
     "db:migrate": "drizzle-kit push",
+    "db:seed": "npm run db:migrate && tsx scripts/seed-db.ts",
     "db:up": "docker compose up -d",
     "db:down": "docker compose down",
     "pre-commit": "node scripts/check-persona-updates.js"

--- a/scripts/seed-db.ts
+++ b/scripts/seed-db.ts
@@ -1,0 +1,53 @@
+#!/usr/bin/env tsx
+
+import { db, pool } from "../server/db";
+import * as schema from "../shared/schema";
+import * as siteSchema from "../shared/site-schema";
+import fs from "fs/promises";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const seedsDir = path.resolve(__dirname, "../server/seeds");
+
+async function seed() {
+  const tables: Record<string, any> = { ...schema, ...siteSchema };
+  const entries = await fs.readdir(seedsDir);
+
+  for (const file of entries) {
+    if (!file.endsWith(".json")) continue;
+    const tableName = path.basename(file, ".json");
+    const table = tables[tableName];
+
+    if (!table) {
+      console.warn(`No schema found for ${tableName}, skipping.`);
+      continue;
+    }
+
+    const filePath = path.join(seedsDir, file);
+    const raw = await fs.readFile(filePath, "utf-8");
+    const records = JSON.parse(raw);
+
+    if (!Array.isArray(records) || records.length === 0) {
+      console.warn(`No records found in ${file}.`);
+      continue;
+    }
+
+    console.log(`Seeding ${records.length} record(s) into ${tableName}...`);
+    await db.insert(table).values(records).onConflictDoNothing();
+  }
+}
+
+seed()
+  .then(() => {
+    console.log("Database seeding complete.");
+  })
+  .catch((err) => {
+    console.error("Error seeding database:", err);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await pool.end();
+  });

--- a/server/seeds/sites.json
+++ b/server/seeds/sites.json
@@ -1,0 +1,7 @@
+[
+  {
+    "siteId": "main",
+    "name": "Main Site",
+    "description": "Default marketing site"
+  }
+]

--- a/server/seeds/users.json
+++ b/server/seeds/users.json
@@ -1,0 +1,9 @@
+[
+  {
+    "email": "admin@example.com",
+    "firstName": "Admin",
+    "lastName": "User",
+    "role": "admin",
+    "isAdmin": true
+  }
+]


### PR DESCRIPTION
## Summary
- seed baseline data from JSON using drizzle-orm
- wire `npm run db:seed` to migrations and add sample seeds
- document seeding workflow in README and Codex

## Testing
- `npm test` *(fails: Failed to load url supertest in health.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68be079981a883319da1d4b33095c56b