### PR TITLE
feat: add memory storage mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,7 @@ HUBSPOT_API_KEY=
 PORT=5000
 BASE_DEV_URL=http://0.0.0.0:5000/api
 BASE_CODEX_URL=https://conduit.replit.app/api
+STORAGE_MODE=memory
 
 # Object storage
 REPLIT_SIDECAR_ENDPOINT=http://127.0.0.1:1106

--- a/Codex.md
+++ b/Codex.md
@@ -4,6 +4,7 @@
 
 ## Summary of Recent Changes
 
+2025-09-09: Added in-memory site storage mode – dev-only JSON seed storage; resets on restart – allows running without Postgres.
 2025-09-07: Switched database driver based on URL host – local DB support – enables all teams to run against local Postgres without Neon.
 
 2025-09-07: Added db:migrate script and test-aware drizzle config – streamline schema updates across environments – teams run migrations consistently without polluting production data.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Environment configuration is managed through Replit's Secrets manager. For local
 | `REPL_ID` | Replit workspace identifier required for OIDC. |
 | `REPLIT_DEV_DOMAIN` | Default Replit domain during development. |
 | `REPLIT_DOMAINS` | Comma-separated list of domains allowed for OIDC callbacks. |
+| `STORAGE_MODE` | Set to `memory` to use in-memory JSON storage for sites. |
 
 
 Switch between Postgres databases by editing `.env`:
@@ -59,6 +60,12 @@ Switch between Postgres databases by editing `.env`:
 - Define `TEST_DATABASE_URL` for a dedicated test Postgres database (e.g., `postgres://user:pass@localhost:5432/testdb`). When present, test runners use this value, keeping test data isolated from the remote database.
 
 `git` must be available in your PATH for repository cloning.
+
+### Memory storage mode
+
+Setting `STORAGE_MODE=memory` launches the API using JSON files loaded into RAM
+instead of Postgres. Seed data lives in `server/data/seed.json`. Because changes
+aren't persisted, restart the server to reset to the contents of that file.
 
 ## Self-Contained Tools
 

--- a/server/data/seed.json
+++ b/server/data/seed.json
@@ -1,0 +1,21 @@
+{
+  "sites": [
+    {
+      "id": "demo-id",
+      "siteId": "demo",
+      "name": "Demo Site",
+      "siteType": "standard",
+      "createdAt": "2024-01-01T00:00:00.000Z",
+      "updatedAt": "2024-01-01T00:00:00.000Z"
+    }
+  ],
+  "siteLeads": [],
+  "siteAnalytics": [],
+  "siteManagers": [],
+  "legalDisclaimers": [],
+  "siteDisclaimers": [],
+  "siteSlides": [],
+  "globalSlides": [],
+  "siteSections": [],
+  "siteMemberships": []
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -3,6 +3,7 @@ import path from "path";
 import fs from "fs";
 import { registerRoutes } from "./routes";
 import { setupVite, serveStatic, log } from "./vite";
+import { setSiteStorage } from "./site-storage";
 
 const BASE_DEV_URL = process.env.BASE_DEV_URL || "http://0.0.0.0:5000/api";
 const BASE_CODEX_URL = process.env.BASE_CODEX_URL || `https://conduit.replit.app/api`;
@@ -64,6 +65,12 @@ app.use((req, res, next) => {
 
 
 (async () => {
+  if (process.env.STORAGE_MODE === 'memory') {
+    const { memorySiteStorage } = await import('./memory-storage');
+    setSiteStorage(memorySiteStorage);
+    log('Using in-memory site storage');
+  }
+
   const server = await registerRoutes(app);
 
   app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {

--- a/server/memory-storage.ts
+++ b/server/memory-storage.ts
@@ -1,0 +1,439 @@
+import fs from "fs";
+import path from "path";
+import { randomUUID } from "crypto";
+import {
+  type Site,
+  type InsertSite,
+  type SiteLead,
+  type InsertSiteLead,
+  type SiteAnalytics,
+  type InsertSiteAnalytics,
+  type SiteManager,
+  type InsertSiteManager,
+  type LegalDisclaimer,
+  type InsertLegalDisclaimer,
+  type SiteDisclaimer,
+  type InsertSiteDisclaimer,
+  type SiteSlide,
+  type InsertSiteSlide,
+  type GlobalSlide,
+  type InsertGlobalSlide,
+  type SiteSection,
+  type InsertSiteSection,
+} from "@shared/site-schema";
+import type { ISiteStorage } from "./site-storage";
+
+interface SeedData {
+  sites: Site[];
+  siteLeads: SiteLead[];
+  siteAnalytics: SiteAnalytics[];
+  siteManagers: SiteManager[];
+  legalDisclaimers: LegalDisclaimer[];
+  siteDisclaimers: SiteDisclaimer[];
+  siteSlides: SiteSlide[];
+  globalSlides: GlobalSlide[];
+  siteSections: SiteSection[];
+  siteMemberships: any[];
+}
+
+function loadSeed(): SeedData {
+  const seedPath = path.join(__dirname, "data", "seed.json");
+  try {
+    const raw = fs.readFileSync(seedPath, "utf-8");
+    return JSON.parse(raw) as SeedData;
+  } catch {
+    return {
+      sites: [],
+      siteLeads: [],
+      siteAnalytics: [],
+      siteManagers: [],
+      legalDisclaimers: [],
+      siteDisclaimers: [],
+      siteSlides: [],
+      globalSlides: [],
+      siteSections: [],
+      siteMemberships: [],
+    };
+  }
+}
+
+export class MemorySiteStorage implements ISiteStorage {
+  private data: SeedData;
+
+  constructor() {
+    this.data = loadSeed();
+  }
+
+  // Site operations
+  async createSite(site: InsertSite): Promise<Site> {
+    const newSite: Site = {
+      ...(site as any),
+      id: randomUUID(),
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    this.data.sites.push(newSite);
+    return newSite;
+  }
+
+  async getSite(siteId: string): Promise<Site | undefined> {
+    return this.data.sites.find((s) => s.siteId === siteId);
+  }
+
+  async getSiteById(id: string): Promise<Site | undefined> {
+    return this.data.sites.find((s) => (s as any).id === id);
+  }
+
+  async updateSite(siteId: string, updates: Partial<InsertSite>): Promise<Site> {
+    const site = await this.getSite(siteId);
+    if (!site) throw new Error("Site not found");
+    Object.assign(site as any, updates, { updatedAt: new Date() });
+    return site;
+  }
+
+  async deleteSite(siteId: string): Promise<void> {
+    this.data.sites = this.data.sites.filter((s) => s.siteId !== siteId);
+  }
+
+  async listSites(): Promise<Site[]> {
+    return [...this.data.sites];
+  }
+
+  // Lead operations
+  async createSiteLead(lead: InsertSiteLead & { siteId: string }): Promise<SiteLead> {
+    const newLead: SiteLead = {
+      ...(lead as any),
+      id: randomUUID(),
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    this.data.siteLeads.push(newLead);
+    return newLead;
+  }
+
+  async getSiteLeads(siteId: string): Promise<SiteLead[]> {
+    return this.data.siteLeads.filter((l) => l.siteId === siteId);
+  }
+
+  async getSiteLeadsByType(siteId: string, formType: string): Promise<SiteLead[]> {
+    return this.data.siteLeads.filter(
+      (l) => l.siteId === siteId && l.formType === formType
+    );
+  }
+
+  async updateSiteLead(
+    leadId: string,
+    updates: Partial<InsertSiteLead>
+  ): Promise<SiteLead> {
+    const lead = this.data.siteLeads.find((l) => (l as any).id === leadId);
+    if (!lead) throw new Error("Lead not found");
+    Object.assign(lead as any, updates, { updatedAt: new Date() });
+    return lead;
+  }
+
+  // Analytics operations
+  async createSiteAnalytics(
+    analytics: InsertSiteAnalytics & { siteId: string }
+  ): Promise<SiteAnalytics> {
+    const newEntry: SiteAnalytics = {
+      ...(analytics as any),
+      id: randomUUID(),
+      createdAt: new Date(),
+    };
+    this.data.siteAnalytics.push(newEntry);
+    return newEntry;
+  }
+
+  async getSiteAnalytics(
+    siteId: string,
+    limit: number = 100
+  ): Promise<SiteAnalytics[]> {
+    return this.data.siteAnalytics
+      .filter((a) => a.siteId === siteId)
+      .slice(-limit)
+      .reverse();
+  }
+
+  // Site manager operations
+  async addSiteManager(siteId: string, userEmail: string): Promise<SiteManager> {
+    const manager: SiteManager = {
+      id: randomUUID(),
+      siteId,
+      userEmail,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    } as any;
+    this.data.siteManagers.push(manager);
+    return manager;
+  }
+
+  async removeSiteManager(siteId: string, userEmail: string): Promise<void> {
+    this.data.siteManagers = this.data.siteManagers.filter(
+      (m) => !(m.siteId === siteId && m.userEmail === userEmail)
+    );
+  }
+
+  async getSiteManagers(siteId: string): Promise<SiteManager[]> {
+    return this.data.siteManagers.filter((m) => m.siteId === siteId);
+  }
+
+  async isSiteManager(siteId: string, userEmail: string): Promise<boolean> {
+    return this.data.siteManagers.some(
+      (m) => m.siteId === siteId && m.userEmail === userEmail
+    );
+  }
+
+  // Legal disclaimer operations
+  async createLegalDisclaimer(
+    disclaimer: InsertLegalDisclaimer
+  ): Promise<LegalDisclaimer> {
+    const newDisclaimer: LegalDisclaimer = {
+      ...(disclaimer as any),
+      id: randomUUID(),
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    this.data.legalDisclaimers.push(newDisclaimer);
+    return newDisclaimer;
+  }
+
+  async getLegalDisclaimer(id: string): Promise<LegalDisclaimer | undefined> {
+    return this.data.legalDisclaimers.find((d) => (d as any).id === id);
+  }
+
+  async updateLegalDisclaimer(
+    id: string,
+    updates: Partial<InsertLegalDisclaimer>
+  ): Promise<LegalDisclaimer> {
+    const disclaimer = await this.getLegalDisclaimer(id);
+    if (!disclaimer) throw new Error("Disclaimer not found");
+    Object.assign(disclaimer as any, updates, { updatedAt: new Date() });
+    return disclaimer;
+  }
+
+  async deleteLegalDisclaimer(id: string): Promise<void> {
+    this.data.legalDisclaimers = this.data.legalDisclaimers.filter(
+      (d) => (d as any).id !== id
+    );
+  }
+
+  async listLegalDisclaimers(): Promise<LegalDisclaimer[]> {
+    return [...this.data.legalDisclaimers];
+  }
+
+  async getAvailableDisclaimersForSiteType(
+    _siteType: string
+  ): Promise<LegalDisclaimer[]> {
+    return [...this.data.legalDisclaimers];
+  }
+
+  // Site disclaimer attachment operations
+  async attachDisclaimerToSite(
+    siteId: string,
+    disclaimerId: string,
+    options?: { displayOrder?: string; linkText?: string }
+  ): Promise<SiteDisclaimer> {
+    const attach: SiteDisclaimer = {
+      id: randomUUID(),
+      siteId,
+      disclaimerId,
+      displayOrder: options?.displayOrder || "0",
+      linkText: options?.linkText || null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    } as any;
+    this.data.siteDisclaimers.push(attach);
+    return attach;
+  }
+
+  async detachDisclaimerFromSite(
+    siteId: string,
+    disclaimerId: string
+  ): Promise<void> {
+    this.data.siteDisclaimers = this.data.siteDisclaimers.filter(
+      (d) => !(d.siteId === siteId && d.disclaimerId === disclaimerId)
+    );
+  }
+
+  async getSiteDisclaimers(
+    siteId: string
+  ): Promise<Array<SiteDisclaimer & { disclaimer: LegalDisclaimer }>> {
+    return this.data.siteDisclaimers
+      .filter((d) => d.siteId === siteId)
+      .map((d) => ({
+        ...d,
+        disclaimer: this.data.legalDisclaimers.find(
+          (l) => l.id === d.disclaimerId
+        )!,
+      }));
+  }
+
+  // Slide operations
+  async createSiteSlide(
+    slide: InsertSiteSlide & { siteId: string }
+  ): Promise<SiteSlide> {
+    const newSlide: SiteSlide = {
+      ...(slide as any),
+      id: randomUUID(),
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    this.data.siteSlides.push(newSlide);
+    return newSlide;
+  }
+
+  async getSiteSlides(siteId: string): Promise<SiteSlide[]> {
+    return this.data.siteSlides.filter((s) => s.siteId === siteId);
+  }
+
+  async getSiteSlide(slideId: string): Promise<SiteSlide | undefined> {
+    return this.data.siteSlides.find((s) => (s as any).id === slideId);
+  }
+
+  async updateSiteSlide(
+    slideId: string,
+    updates: Partial<InsertSiteSlide>
+  ): Promise<SiteSlide> {
+    const slide = await this.getSiteSlide(slideId);
+    if (!slide) throw new Error("Slide not found");
+    Object.assign(slide as any, updates, { updatedAt: new Date() });
+    return slide;
+  }
+
+  async deleteSiteSlide(slideId: string): Promise<void> {
+    this.data.siteSlides = this.data.siteSlides.filter(
+      (s) => (s as any).id !== slideId
+    );
+  }
+
+  async reorderSiteSlides(
+    siteId: string,
+    slideOrders: Array<{ id: string; slideOrder: string }>
+  ): Promise<void> {
+    const slides = this.data.siteSlides.filter((s) => s.siteId === siteId);
+    slideOrders.forEach(({ id, slideOrder }) => {
+      const slide = slides.find((s) => (s as any).id === id);
+      if (slide) (slide as any).slideOrder = slideOrder;
+    });
+  }
+
+  // Global slide operations
+  async getGlobalSlides(): Promise<GlobalSlide[]> {
+    return [...this.data.globalSlides];
+  }
+
+  async getGlobalSlideByKey(slideKey: string): Promise<GlobalSlide | undefined> {
+    return this.data.globalSlides.find((g) => (g as any).slideKey === slideKey);
+  }
+
+  async createGlobalSlide(slideData: InsertGlobalSlide): Promise<GlobalSlide> {
+    const slide: GlobalSlide = {
+      ...(slideData as any),
+      id: randomUUID(),
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    this.data.globalSlides.push(slide);
+    return slide;
+  }
+
+  async updateGlobalSlideVisibility(
+    slideKey: string,
+    isVisible: boolean
+  ): Promise<GlobalSlide | null> {
+    const slide = await this.getGlobalSlideByKey(slideKey);
+    if (!slide) return null;
+    (slide as any).isVisible = isVisible;
+    (slide as any).updatedAt = new Date();
+    return slide;
+  }
+
+  // Site sections operations
+  async getSiteSections(siteId: string): Promise<SiteSection[]> {
+    return this.data.siteSections.filter((s) => s.siteId === siteId);
+  }
+
+  async getSiteSection(sectionId: string): Promise<SiteSection | undefined> {
+    return this.data.siteSections.find((s) => (s as any).id === sectionId);
+  }
+
+  async createSiteSection(sectionData: InsertSiteSection): Promise<SiteSection> {
+    const section: SiteSection = {
+      ...(sectionData as any),
+      id: randomUUID(),
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    this.data.siteSections.push(section);
+    return section;
+  }
+
+  async updateSiteSection(
+    sectionId: string,
+    updates: Partial<InsertSiteSection>
+  ): Promise<SiteSection> {
+    const section = await this.getSiteSection(sectionId);
+    if (!section) throw new Error("Section not found");
+    Object.assign(section as any, updates, { updatedAt: new Date() });
+    return section;
+  }
+
+  async deleteSiteSection(sectionId: string): Promise<void> {
+    this.data.siteSections = this.data.siteSections.filter(
+      (s) => (s as any).id !== sectionId
+    );
+  }
+
+  // Site membership operations (simplified)
+  async getUserMemberships(userId: string): Promise<any[]> {
+    return this.data.siteMemberships.filter((m) => m.userId === userId);
+  }
+
+  async getSiteMemberships(siteId: string): Promise<any[]> {
+    return this.data.siteMemberships.filter((m) => m.siteId === siteId);
+  }
+
+  async createSiteMembership(membershipData: any): Promise<any> {
+    const membership = {
+      ...membershipData,
+      id: randomUUID(),
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    this.data.siteMemberships.push(membership);
+    return membership;
+  }
+
+  async updateSiteMembership(
+    siteId: string,
+    userId: string,
+    updates: any
+  ): Promise<any> {
+    const membership = this.data.siteMemberships.find(
+      (m) => m.siteId === siteId && m.userId === userId
+    );
+    if (!membership) return null;
+    Object.assign(membership, updates, { updatedAt: new Date() });
+    return membership;
+  }
+
+  async deleteSiteMembership(siteId: string, userId: string): Promise<boolean> {
+    const before = this.data.siteMemberships.length;
+    this.data.siteMemberships = this.data.siteMemberships.filter(
+      (m) => !(m.siteId === siteId && m.userId === userId)
+    );
+    return this.data.siteMemberships.length < before;
+  }
+
+  // Access control
+  async checkSiteAccess(
+    _siteId: string,
+    _userEmail: string,
+    isAdmin: boolean
+  ): Promise<boolean> {
+    return isAdmin || true;
+  }
+}
+
+export const memorySiteStorage = new MemorySiteStorage();
+

--- a/server/site-storage.ts
+++ b/server/site-storage.ts
@@ -1133,7 +1133,11 @@ export class DatabaseSiteStorage implements ISiteStorage {
   }
 }
 
-export const siteStorage = new DatabaseSiteStorage();
+export let siteStorage: ISiteStorage = new DatabaseSiteStorage();
+
+export function setSiteStorage(storage: ISiteStorage) {
+  siteStorage = storage;
+}
 
 export async function updateSiteLead(
   leadId: string,


### PR DESCRIPTION
## Summary
- add in-memory site storage backed by JSON files
- allow switching storage modes via STORAGE_MODE env var
- document memory storage usage and seed reset process

## Testing
- `npm test` *(fails: Failed to load url supertest)*
- `npm run lint` *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68be08beec288331b264b61cf46ccfb4