### PR TITLE
docs: document local development modes

### DIFF
--- a/Codex.md
+++ b/Codex.md
@@ -4,6 +4,7 @@
 
 ## Summary of Recent Changes
 
+2025-09-09: Documented local development modes for Docker Postgres and in-memory setups – clarify environment variables and seed scripts – developers can choose Postgres containers or memory storage.
 2025-09-09: Added in-memory site storage mode – dev-only JSON seed storage; resets on restart – allows running without Postgres.
 2025-09-07: Switched database driver based on URL host – local DB support – enables all teams to run against local Postgres without Neon.
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,16 @@ Required packages include `libnss3`, `libatk-1.0-0`, and `fonts-liberation`.
   - Requires `git` and network access to import public repositories.
   - Automatically opens your browser to the explorer page.
 
+### Local Development Modes
+
+Choose how to run the stack during development. Copy `.env.example` to `.env` and provide values for required
+variables like `DATABASE_URL`, `SESSION_SECRET`, and others listed below.
+
+- **Docker Postgres**: `npm run db:up`, `npm run db:migrate`, `npm run db:seed`, `npm run dev`
+  - Spins up a Postgres container and loads seed data from `server/seeds/`.
+- **In-memory**: set `AUTH_DISABLED=true` and `STORAGE_MODE=memory`, then `npm run dev`
+  - Bypasses authentication and uses `server/data/seed.json` for ephemeral data.
+
 ### Environment variables
 
 Environment configuration is managed through Replit's Secrets manager. For local development, copy `.env.example` to `.env` and provide values. Keep this sample file in sync whenever new variables are introduced. Database URLs must use the standard Postgres URI format (e.g., `postgres://user:pass@localhost:5432/db`).


### PR DESCRIPTION
## Summary
- document Docker Postgres and in-memory development workflows
- note required env vars and seed data locations
- log changes in Codex

## Testing
- `npm test` *(fails: Failed to load url supertest)*

------
https://chatgpt.com/codex/tasks/task_e_68be09dcbc708331a54f303d7699ecb0