### PR TITLE
feat: externalize default slide config

### DIFF
--- a/Codex.md
+++ b/Codex.md
@@ -4,6 +4,7 @@
 
 ## Summary of Recent Changes
 
+2025-09-11: Externalized default slide metadata to seeds with object storage paths – centralize configuration for branding – Replit styling and Card-Builder exports can swap slide assets per deployment.
 2025-09-10: Added boot tests for memory and Postgres storage using Playwright – verify /api/health and lead submission – ensure server boot and persistence across backends.
 2025-09-09: Documented local development modes for Docker Postgres and in-memory setups – clarify environment variables and seed scripts – developers can choose Postgres containers or memory storage.
 2025-09-09: Added in-memory site storage mode – dev-only JSON seed storage; resets on restart – allows running without Postgres.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,20 @@ This command applies pending schema changes and inserts records from `server/see
 
 `git` must be available in your PATH for repository cloning.
 
+### Overriding slide assets
+
+Default presentation slides are listed in `server/seeds/slides.json` using relative
+file names. At runtime, the server prefixes each entry with the first path from
+`PUBLIC_OBJECT_SEARCH_PATHS` to build full URLs.
+
+To customize slides for a deployment:
+
+1. Upload images to a bucket referenced by `PUBLIC_OBJECT_SEARCH_PATHS`.
+2. Replace file names in `server/seeds/slides.json` with your assets.
+3. Rerun `npm run db:seed` or create a new site to apply the changes.
+
+This allows each environment to ship branded decks without modifying source code.
+
 ### Memory storage mode
 
 Setting `STORAGE_MODE=memory` launches the API using JSON files loaded into RAM

--- a/server/seeds/slides.json
+++ b/server/seeds/slides.json
@@ -1,0 +1,19 @@
+[
+  { "title": "Welcome to Mining Syndicate", "imageUrl": "Mining Syndicate Presentation-1_1755027297237.jpg", "slideOrder": "1", "description": "Introduction slide" },
+  { "title": "Mining Infrastructure Overview", "imageUrl": "Mining Syndicate Presentation-2_1755027297237.jpg", "slideOrder": "2", "description": "Infrastructure overview" },
+  { "title": "Investment Opportunities", "imageUrl": "Mining Syndicate Presentation-3_1755027297237.jpg", "slideOrder": "3", "description": "Investment details" },
+  { "title": "Technology Stack", "imageUrl": "Mining Syndicate Presentation-4_1755027297238.jpg", "slideOrder": "4", "description": "Technology overview" },
+  { "title": "Market Analysis", "imageUrl": "Mining Syndicate Presentation-5_1755027297238.jpg", "slideOrder": "5", "description": "Market analysis" },
+  { "title": "Financial Projections", "imageUrl": "Mining Syndicate Presentation-6_1755027297238.jpg", "slideOrder": "6", "description": "Financial projections" },
+  { "title": "Risk Management", "imageUrl": "Mining Syndicate Presentation-7_1755027297238.jpg", "slideOrder": "7", "description": "Risk management" },
+  { "title": "Partnership Strategy", "imageUrl": "Mining Syndicate Presentation-8_1755027297239.jpg", "slideOrder": "8", "description": "Partnership strategy" },
+  { "title": "Operational Excellence", "imageUrl": "Mining Syndicate Presentation-9_1755027297239.jpg", "slideOrder": "9", "description": "Operational excellence" },
+  { "title": "Sustainability Focus", "imageUrl": "Mining Syndicate Presentation-10_1755027297239.jpg", "slideOrder": "10", "description": "Sustainability focus" },
+  { "title": "Community Impact", "imageUrl": "Mining Syndicate Presentation-11_1755027297239.jpg", "slideOrder": "11", "description": "Community impact" },
+  { "title": "Innovation Pipeline", "imageUrl": "Mining Syndicate Presentation-12_1755027297240.jpg", "slideOrder": "12", "description": "Innovation pipeline" },
+  { "title": "Global Expansion", "imageUrl": "Mining Syndicate Presentation-13_1755027297240.jpg", "slideOrder": "13", "description": "Global expansion" },
+  { "title": "Regulatory Compliance", "imageUrl": "Mining Syndicate Presentation-14_1755027297240.jpg", "slideOrder": "14", "description": "Regulatory compliance" },
+  { "title": "Team Expertise", "imageUrl": "Mining Syndicate Presentation-15_1755027297240.jpg", "slideOrder": "15", "description": "Team expertise" },
+  { "title": "Success Metrics", "imageUrl": "Mining Syndicate Presentation-16_1755027297241.jpg", "slideOrder": "16", "description": "Success metrics" },
+  { "title": "Future Vision", "imageUrl": "Mining Syndicate Presentation-17_1755027297241.jpg", "slideOrder": "17", "description": "Future vision" }
+]

--- a/server/site-routes.ts
+++ b/server/site-routes.ts
@@ -1,6 +1,8 @@
 import type { Express, Response } from "express";
 import express from "express";
 import path from "path";
+import { readFile } from "fs/promises";
+import { fileURLToPath } from "url";
 import { siteStorage, updateSiteLead } from "./site-storage";
 import { storage } from "./storage";
 import { qrGenerator } from "./qr-generator";
@@ -12,37 +14,25 @@ import { checkSiteAccess, requireAdmin } from "./site-access-control";
 import { isAuthenticated } from "./google-auth";
 import { z } from "zod";
 
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
 // Function to create default slides for a site
 async function createDefaultSlides(siteId: string) {
-  const defaultSlides = [
-    { title: 'Welcome to Mining Syndicate', imageUrl: '/api/assets/Mining Syndicate Presentation-1_1755027297237.jpg', slideOrder: '1', description: 'Introduction slide' },
-    { title: 'Mining Infrastructure Overview', imageUrl: '/api/assets/Mining Syndicate Presentation-2_1755027297237.jpg', slideOrder: '2', description: 'Infrastructure overview' },
-    { title: 'Investment Opportunities', imageUrl: '/api/assets/Mining Syndicate Presentation-3_1755027297237.jpg', slideOrder: '3', description: 'Investment details' },
-    { title: 'Technology Stack', imageUrl: '/api/assets/Mining Syndicate Presentation-4_1755027297238.jpg', slideOrder: '4', description: 'Technology overview' },
-    { title: 'Market Analysis', imageUrl: '/api/assets/Mining Syndicate Presentation-5_1755027297238.jpg', slideOrder: '5', description: 'Market analysis' },
-    { title: 'Financial Projections', imageUrl: '/api/assets/Mining Syndicate Presentation-6_1755027297238.jpg', slideOrder: '6', description: 'Financial projections' },
-    { title: 'Risk Management', imageUrl: '/api/assets/Mining Syndicate Presentation-7_1755027297238.jpg', slideOrder: '7', description: 'Risk management' },
-    { title: 'Partnership Strategy', imageUrl: '/api/assets/Mining Syndicate Presentation-8_1755027297239.jpg', slideOrder: '8', description: 'Partnership strategy' },
-    { title: 'Operational Excellence', imageUrl: '/api/assets/Mining Syndicate Presentation-9_1755027297239.jpg', slideOrder: '9', description: 'Operational excellence' },
-    { title: 'Sustainability Focus', imageUrl: '/api/assets/Mining Syndicate Presentation-10_1755027297239.jpg', slideOrder: '10', description: 'Sustainability focus' },
-    { title: 'Community Impact', imageUrl: '/api/assets/Mining Syndicate Presentation-11_1755027297239.jpg', slideOrder: '11', description: 'Community impact' },
-    { title: 'Innovation Pipeline', imageUrl: '/api/assets/Mining Syndicate Presentation-12_1755027297240.jpg', slideOrder: '12', description: 'Innovation pipeline' },
-    { title: 'Global Expansion', imageUrl: '/api/assets/Mining Syndicate Presentation-13_1755027297240.jpg', slideOrder: '13', description: 'Global expansion' },
-    { title: 'Regulatory Compliance', imageUrl: '/api/assets/Mining Syndicate Presentation-14_1755027297240.jpg', slideOrder: '14', description: 'Regulatory compliance' },
-    { title: 'Team Expertise', imageUrl: '/api/assets/Mining Syndicate Presentation-15_1755027297240.jpg', slideOrder: '15', description: 'Team expertise' },
-    { title: 'Success Metrics', imageUrl: '/api/assets/Mining Syndicate Presentation-16_1755027297241.jpg', slideOrder: '16', description: 'Success metrics' },
-    { title: 'Future Vision', imageUrl: '/api/assets/Mining Syndicate Presentation-17_1755027297241.jpg', slideOrder: '17', description: 'Future vision' }
-  ];
+  const slidesPath = path.join(__dirname, "seeds", "slides.json");
+  const raw = await readFile(slidesPath, "utf-8");
+  const defaultSlides: Array<{ title: string; imageUrl: string; slideOrder: string; description: string }> = JSON.parse(raw);
+  const [publicPath] = new ObjectStorageService().getPublicObjectSearchPaths();
 
   for (const slide of defaultSlides) {
+    const imageUrl = path.posix.join(publicPath, slide.imageUrl);
     await siteStorage.createSiteSlide({
       siteId: siteId,
       title: slide.title,
-      imageUrl: slide.imageUrl,
+      imageUrl,
       slideOrder: slide.slideOrder,
       isVisible: true,
-      slideType: 'image',
-      description: slide.description
+      slideType: "image",
+      description: slide.description,
     });
   }
 }


### PR DESCRIPTION
## Summary
- move default slide metadata to `server/seeds/slides.json` with relative paths
- load slide seeds in `createDefaultSlides` and prefix with public object search path
- document overriding slide assets per deployment and log change in Codex

## Testing
- `npm test` *(fails: 48 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68be12ef994c83319cb13b3bd399c761