### PR TITLE
feat: add memory object storage fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,7 @@ BASE_CODEX_URL=https://conduit.replit.app/api
 STORAGE_MODE=memory
 
 # Object storage
+# Leave REPLIT_SIDECAR_ENDPOINT unset to use in-memory storage locally
 REPLIT_SIDECAR_ENDPOINT=http://127.0.0.1:1106
 PUBLIC_OBJECT_SEARCH_PATHS=
 PRIVATE_OBJECT_DIR=

--- a/Codex.md
+++ b/Codex.md
@@ -4,6 +4,7 @@
 
 ## Summary of Recent Changes
 
+2025-09-13: Added fallback in-memory object storage when REPLIT_SIDECAR_ENDPOINT is missing – support Replit-independent local development – uploads persist only for the process lifetime.
 2025-09-12: Introduced pino-based JSON logger with per-request IDs – unify structured logging and enable traceability – downstream log consumers must parse JSON and respect the `reqId` field for correlation.
 
 2025-09-07: Added rate limiting and stricter lead validation – throttle spam and enforce clean contact data – marketing analytics receive higher fidelity lead metrics.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Environment configuration is managed through Replit's Secrets manager. For local
 | `PORT` | Port for the combined Express and Vite servers (defaults to `5000`). |
 | `BASE_DEV_URL` | Local API base URL used during initialization. |
 | `BASE_CODEX_URL` | Fallback Codex API endpoint when the local API is unavailable. |
-| `REPLIT_SIDECAR_ENDPOINT` | Internal endpoint for object storage auth on Replit. |
+| `REPLIT_SIDECAR_ENDPOINT` | Internal endpoint for object storage auth on Replit; when absent, storage falls back to an in-memory filesystem for local development. |
 | `PUBLIC_OBJECT_SEARCH_PATHS` | Comma-separated object storage paths for public assets. |
 | `PRIVATE_OBJECT_DIR` | Object storage path for private uploads. |
 | `ISSUER_URL` | OIDC issuer for Replit authentication. |
@@ -85,7 +85,9 @@ This command applies pending schema changes and inserts records from `server/see
 
 Default presentation slides are listed in `server/seeds/slides.json` using relative
 file names. At runtime, the server prefixes each entry with the first path from
-`PUBLIC_OBJECT_SEARCH_PATHS` to build full URLs.
+`PUBLIC_OBJECT_SEARCH_PATHS` to build full URLs. If the Replit sidecar isn't
+available, uploads are stored in an in-memory filesystem and are cleared on
+restart.
 
 To customize slides for a deployment:
 

--- a/server/__tests__/objectStorage.test.ts
+++ b/server/__tests__/objectStorage.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { Storage } from '@google-cloud/storage';
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+describe('objectStorage client selection', () => {
+  it('uses google storage when REPLIT_SIDECAR_ENDPOINT is set', async () => {
+    process.env.REPLIT_SIDECAR_ENDPOINT = 'http://127.0.0.1:1106';
+    const mod = await import('../objectStorage');
+    expect(mod.objectStorageClient).toBeInstanceOf(Storage);
+  });
+
+  it('uses memory storage when REPLIT_SIDECAR_ENDPOINT is absent', async () => {
+    delete process.env.REPLIT_SIDECAR_ENDPOINT;
+    process.env.PRIVATE_OBJECT_DIR = '/bucket';
+    const mod = await import('../objectStorage');
+    expect(mod.objectStorageClient.constructor.name).toBe('MemoryStorage');
+    const service = new mod.ObjectStorageService();
+    const url = await service.getSlideUploadURL();
+    expect(url).toMatch(/\/bucket\/slides\//);
+  });
+});


### PR DESCRIPTION
## Summary
- fall back to in-memory object storage when `REPLIT_SIDECAR_ENDPOINT` is unset
- document optional sidecar endpoint in README and `.env.example`
- log the change in `Codex.md` and add tests for sidecar vs fallback modes

## Testing
- `npm test` *(fails: Failed to load url pino/supertest and server-boot tests)*

------
https://chatgpt.com/codex/tasks/task_e_68be190a03048331b6ba480ce1e8c8fe