### PR TITLE
test: cover site creation defaults

### DIFF
--- a/Codex.md
+++ b/Codex.md
@@ -3,6 +3,7 @@
 > **Entry Template:** `YYYY-MM-DD: summary – reason – impact`
 
 ## Summary of Recent Changes
+2025-09-14: Added site creation tests for standard, pitch, and collective setups – verify default content added – ensures new sites start with expected slides, forms, and sections.
 
 2025-09-13: Added fallback in-memory object storage when REPLIT_SIDECAR_ENDPOINT is missing – support Replit-independent local development – uploads persist only for the process lifetime.
 2025-09-12: Introduced pino-based JSON logger with per-request IDs – unify structured logging and enable traceability – downstream log consumers must parse JSON and respect the `reqId` field for correlation.

--- a/server/__tests__/site-create.test.ts
+++ b/server/__tests__/site-create.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import express from 'express';
+import { request as pwRequest, APIRequestContext } from 'playwright';
+import path from 'path';
+import fs from 'fs/promises';
+import { fileURLToPath } from 'url';
+
+async function startServer() {
+  const routes = await import('../routes');
+  const app = express();
+  app.use(express.json());
+  app.use(express.urlencoded({ extended: false }));
+  const httpServer = await routes.registerRoutes(app);
+  await new Promise<void>((resolve) => httpServer.listen(0, resolve));
+  const port = (httpServer.address() as any).port;
+  return { httpServer, baseURL: `http://127.0.0.1:${port}` };
+}
+
+describe('site creation defaults', () => {
+  let server: any;
+  let context: APIRequestContext;
+
+  beforeEach(async () => {
+    process.env.AUTH_DISABLED = 'true';
+    process.env.STORAGE_MODE = 'memory';
+    process.env.PUBLIC_OBJECT_SEARCH_PATHS = '/public';
+    process.env.DATABASE_URL =
+      process.env.DATABASE_URL || 'postgres://postgres:postgres@localhost:5432/postgres';
+
+    const dbModule = await import('../db');
+    (dbModule.db.execute as any) = async () => {};
+    (dbModule.pool.end as any) = async () => {};
+
+    const { setSiteStorage } = await import('../site-storage');
+    const { MemorySiteStorage } = await import('../memory-storage');
+    setSiteStorage(new MemorySiteStorage());
+
+    const started = await startServer();
+    server = started.httpServer;
+    context = await pwRequest.newContext({ baseURL: started.baseURL });
+  });
+
+  afterEach(async () => {
+    await context.dispose();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    delete process.env.AUTH_DISABLED;
+    delete process.env.STORAGE_MODE;
+    delete process.env.PUBLIC_OBJECT_SEARCH_PATHS;
+    vi.restoreAllMocks();
+  });
+
+  it('adds default slides for standard sites', async () => {
+    const res = await context.post('/api/sites', {
+      data: { siteId: 'standard-test', name: 'Standard Test', siteType: 'standard' }
+    });
+    expect(res.status()).toBe(200);
+
+    const { siteStorage } = await import('../site-storage');
+    const slides = await siteStorage.getSiteSlides('standard-test');
+
+    const slidesPath = fileURLToPath(new URL('../seeds/slides.json', import.meta.url));
+    const expected = JSON.parse(await fs.readFile(slidesPath, 'utf-8'));
+    expect(slides).toHaveLength(expected.length);
+  });
+
+  it('assigns default forms for pitch sites', async () => {
+    const assignments: any[] = [];
+    const { storage } = await import('../storage');
+    vi.spyOn(storage, 'getFormTemplates').mockResolvedValue([
+      { id: 'learn', name: 'Learn More', isBuiltIn: true },
+      { id: 'contact', name: 'Contact Sales', isBuiltIn: true },
+      { id: 'demo', name: 'Product Demo', isBuiltIn: true }
+    ] as any);
+    vi.spyOn(storage, 'assignFormToSite').mockImplementation(async (assignment: any) => {
+      assignments.push(assignment);
+      return { id: String(assignments.length), ...assignment } as any;
+    });
+
+    const res = await context.post('/api/sites', {
+      data: {
+        siteId: 'pitch-test',
+        name: 'Pitch Test',
+        siteType: 'pitch-site',
+        presentationMode: 'configure-now'
+      }
+    });
+    expect(res.status()).toBe(200);
+    expect(assignments).toHaveLength(3);
+    expect(assignments.map(a => a.formTemplateId)).toEqual(['learn', 'contact', 'demo']);
+    expect(assignments[0].cardPosition).toBe('main');
+    expect(assignments[2].cardPosition).toBe('sidebar');
+  });
+
+  it('creates collective defaults and join card', async () => {
+    const assignments: any[] = [];
+    const { storage } = await import('../storage');
+    vi.spyOn(storage, 'getJoinCardTemplate').mockResolvedValue({ id: 'join', name: 'Join Card', isBuiltIn: true } as any);
+    vi.spyOn(storage, 'assignFormToSite').mockImplementation(async (assignment: any) => {
+      assignments.push(assignment);
+      return { id: '1', ...assignment } as any;
+    });
+
+    const res = await context.post('/api/sites', {
+      data: {
+        siteId: 'collective-test',
+        name: 'Collective Test',
+        siteType: 'collective',
+        presentationMode: 'configure-now'
+      }
+    });
+    expect(res.status()).toBe(200);
+    expect(assignments).toHaveLength(1);
+    expect(assignments[0].overrideConfig.title).toContain('Collective Test');
+
+    const { siteStorage } = await import('../site-storage');
+    const site = await siteStorage.getSite('collective-test');
+    const settings = typeof site?.collectiveSettings === 'string'
+      ? JSON.parse(site.collectiveSettings as any)
+      : site?.collectiveSettings;
+    expect(settings.joinType).toBe('public');
+    expect(site?.landingConfig.heroTitle).toBe(`Welcome to ${site?.name}`);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add Playwright/Vitest tests that validate default slides for standard sites, default forms for pitch sites, and default sections for collectives
- document new site creation tests in Codex

## Testing
- `npx playwright install --with-deps` *(fails: Domain forbidden)*
- `npm test` *(fails: missing modules such as pino and supertest)*

------
https://chatgpt.com/codex/tasks/task_e_68be1a23af80833199e8d7e34c098cf8