### PR TITLE
feat: centralize server configuration

### DIFF
--- a/Codex.md
+++ b/Codex.md
@@ -3,6 +3,7 @@
 > **Entry Template:** `YYYY-MM-DD: summary – reason – impact`
 
 ## Summary of Recent Changes
+2025-09-15: Centralized environment config with startup validation – catch misconfiguration early – consolidates server settings and removes scattered `process.env` usage.
 2025-09-14: Added site creation tests for standard, pitch, and collective setups – verify default content added – ensures new sites start with expected slides, forms, and sections.
 
 2025-09-13: Added fallback in-memory object storage when REPLIT_SIDECAR_ENDPOINT is missing – support Replit-independent local development – uploads persist only for the process lifetime.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ variables like `DATABASE_URL`, `SESSION_SECRET`, and others listed below.
 
 ### Environment variables
 
-Environment configuration is managed through Replit's Secrets manager. For local development, copy `.env.example` to `.env` and provide values. Keep this sample file in sync whenever new variables are introduced. Database URLs must use the standard Postgres URI format (e.g., `postgres://user:pass@localhost:5432/db`).
+Environment configuration is managed through Replit's Secrets manager. For local development, copy `.env.example` to `.env` and provide values. The server reads settings through `server/config.ts`, which validates required variables at startup and throws descriptive errors when they're missing. Keep this sample file in sync whenever new variables are introduced. Database URLs must use the standard Postgres URI format (e.g., `postgres://user:pass@localhost:5432/db`).
 
 | Variable | Purpose |
 |----------|---------|
@@ -63,6 +63,7 @@ Environment configuration is managed through Replit's Secrets manager. For local
 | `REPLIT_DOMAINS` | Comma-separated list of domains allowed for OIDC callbacks. |
 | `STORAGE_MODE` | Set to `memory` to use in-memory JSON storage for sites. |
 
+The server exits on startup if `DATABASE_URL` is missing. When `AUTH_DISABLED` is not `true`, Google and Replit auth credentials (`GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `REPL_ID`) must also be provided.
 
 Switch between Postgres databases by editing `.env`:
 

--- a/server/__tests__/objectStorage.test.ts
+++ b/server/__tests__/objectStorage.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { Storage } from '@google-cloud/storage';
 
+process.env.DATABASE_URL = process.env.DATABASE_URL || 'postgres://postgres:postgres@localhost:5432/postgres';
+
 afterEach(() => {
   vi.resetModules();
 });

--- a/server/card-builder.ts
+++ b/server/card-builder.ts
@@ -3,6 +3,7 @@ import { createServer } from "http";
 import path from "path";
 import open from "open";
 import { setupViteFor, log } from "./vite";
+import { config } from './config';
 
 const app = express();
 
@@ -12,7 +13,7 @@ const server = createServer(app);
   const rootDir = path.resolve(import.meta.dirname, "..", "packages", "card-builder");
   await setupViteFor(app, server, rootDir, "/card-builder");
 
-  const port = parseInt(process.env.PORT || "5000", 10);
+  const port = config.port;
   server.listen({ port, host: "0.0.0.0", reusePort: true }, () => {
     log(`card builder dev server running on port ${port}`);
     void open(`http://localhost:${port}/card-builder`, { wait: false }).catch(() => {});

--- a/server/config.ts
+++ b/server/config.ts
@@ -1,0 +1,86 @@
+import { z } from 'zod';
+
+const envSchema = z.object({
+  NODE_ENV: z.string().default('development'),
+  PORT: z.coerce.number().default(5000),
+  BASE_DEV_URL: z.string().default('http://0.0.0.0:5000/api'),
+  BASE_CODEX_URL: z.string().default('https://conduit.replit.app/api'),
+  DATABASE_URL: z.string().optional(),
+  TEST_DATABASE_URL: z.string().optional(),
+  SESSION_SECRET: z
+    .string()
+    .default('mining-syndicate-dev-secret-2025-very-secure-random-string-32chars-minimum'),
+  HUBSPOT_API_KEY: z.string().optional(),
+  AUTH_DISABLED: z.string().optional(),
+  STORAGE_MODE: z.string().optional(),
+  REPLIT_DOMAINS: z.string().optional(),
+  REPLIT_DEV_DOMAIN: z.string().optional(),
+  ISSUER_URL: z.string().optional(),
+  REPL_ID: z.string().optional(),
+  GOOGLE_CLIENT_ID: z.string().optional(),
+  GOOGLE_CLIENT_SECRET: z.string().optional(),
+  GOOGLE_OAUTH_CALLBACK_URL: z.string().optional(),
+  REPLIT_SIDECAR_ENDPOINT: z.string().optional(),
+  PUBLIC_OBJECT_SEARCH_PATHS: z.string().optional(),
+  PRIVATE_OBJECT_DIR: z.string().optional(),
+  LOG_LEVEL: z.string().default('info'),
+});
+
+const env = envSchema.parse(process.env);
+
+const authDisabled = env.AUTH_DISABLED === 'true';
+
+const databaseUrl = env.NODE_ENV === 'test'
+  ? env.TEST_DATABASE_URL ?? env.DATABASE_URL
+  : env.DATABASE_URL;
+
+if (!databaseUrl) {
+  throw new Error('DATABASE_URL must be set. Did you forget to provision a database?');
+}
+
+if (!authDisabled) {
+  if (!env.GOOGLE_CLIENT_ID) {
+    throw new Error('GOOGLE_CLIENT_ID is required when authentication is enabled');
+  }
+  if (!env.GOOGLE_CLIENT_SECRET) {
+    throw new Error('GOOGLE_CLIENT_SECRET is required when authentication is enabled');
+  }
+  if (!env.REPL_ID) {
+    throw new Error('REPL_ID is required when authentication is enabled');
+  }
+}
+
+const config = {
+  nodeEnv: env.NODE_ENV,
+  port: env.PORT,
+  baseDevUrl: env.BASE_DEV_URL,
+  baseCodexUrl: env.BASE_CODEX_URL,
+  hubspotApiKey: env.HUBSPOT_API_KEY,
+  authDisabled,
+  storageMode: env.STORAGE_MODE,
+  sessionSecret: env.SESSION_SECRET,
+  databaseUrl,
+  replit: {
+    domains: (env.REPLIT_DOMAINS ?? env.REPLIT_DEV_DOMAIN ?? 'conduit.replit.app')
+      .split(',')
+      .map((d) => d.trim())
+      .filter(Boolean),
+    issuerUrl: env.ISSUER_URL ?? 'https://replit.com/oidc',
+    replId: env.REPL_ID,
+  },
+  google: {
+    clientId: env.GOOGLE_CLIENT_ID,
+    clientSecret: env.GOOGLE_CLIENT_SECRET,
+    oauthCallbackUrl:
+      env.GOOGLE_OAUTH_CALLBACK_URL ?? 'https://conduit.replit.app/api/auth/google/callback',
+  },
+  objectStorage: {
+    replitSidecarEndpoint: env.REPLIT_SIDECAR_ENDPOINT,
+    publicObjectSearchPaths: env.PUBLIC_OBJECT_SEARCH_PATHS,
+    privateObjectDir: env.PRIVATE_OBJECT_DIR,
+  },
+  logLevel: env.LOG_LEVEL,
+};
+
+export type Config = typeof config;
+export { config };

--- a/server/db.ts
+++ b/server/db.ts
@@ -6,19 +6,11 @@ import { drizzle as pgDrizzle } from "drizzle-orm/node-postgres";
 import ws from "ws";
 import * as schema from "@shared/schema";
 import * as siteSchema from "@shared/site-schema";
+import { config } from "./config";
 
 neonConfig.webSocketConstructor = ws;
 
-const connectionString =
-  process.env.NODE_ENV === "test"
-    ? process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL
-    : process.env.DATABASE_URL;
-
-if (!connectionString) {
-  throw new Error(
-    "DATABASE_URL must be set. Did you forget to provision a database?",
-  );
-}
+const connectionString = config.databaseUrl;
 
 const url = new URL(connectionString);
 const isLocal = ["localhost", "127.0.0.1"].includes(url.hostname);

--- a/server/explorer.ts
+++ b/server/explorer.ts
@@ -11,6 +11,7 @@ import { setupViteFor, log } from "./vite";
 import { buildFileTree } from "../packages/code-explorer/file-tree.js";
 import { applyPatchToFile } from "./save";
 import { createFunctionsRouter } from "./functions";
+import { config } from './config';
 const exec = promisify(execCb);
 
 const app = express();
@@ -113,7 +114,7 @@ const server = createServer(app);
   const rootDir = path.resolve(import.meta.dirname, "..", "packages", "code-explorer");
   await setupViteFor(app, server, rootDir, "/code-explorer");
 
-  const port = parseInt(process.env.PORT || "5000", 10);
+  const port = config.port;
   server.listen({ port, host: "0.0.0.0", reusePort: true }, () => {
     log(`explorer dev server running on port ${port}`);
     void open(`http://localhost:${port}/code-explorer`, { wait: false }).catch(

--- a/server/hubspot.ts
+++ b/server/hubspot.ts
@@ -1,7 +1,8 @@
 import { Client } from "@hubspot/api-client";
 import { logger } from './logger';
+import { config } from './config';
 
-const hubspotClient = new Client({ accessToken: process.env.HUBSPOT_API_KEY });
+const hubspotClient = new Client({ accessToken: config.hubspotApiKey });
 
 export interface HubSpotContact {
   email: string;
@@ -114,7 +115,7 @@ export async function submitToHubSpotForm(formId: string, contactData: any): Pro
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': `Bearer ${process.env.HUBSPOT_API_KEY}`
+        'Authorization': `Bearer ${config.hubspotApiKey}`
       },
       body: JSON.stringify(formData)
     });
@@ -285,7 +286,7 @@ export async function listContactProperties(): Promise<void> {
 export async function testHubSpotConnection(): Promise<boolean> {
   try {
     logger.info('Testing HubSpot API connection...');
-    logger.info('API Key format:', process.env.HUBSPOT_API_KEY ? `${process.env.HUBSPOT_API_KEY.substring(0, 10)}...` : 'Not found');
+    logger.info('API Key format:', config.hubspotApiKey ? `${config.hubspotApiKey.substring(0, 10)}...` : 'Not found');
     
     const response = await hubspotClient.crm.contacts.basicApi.getPage(1, undefined, undefined, undefined, undefined, false);
     logger.info('HubSpot connection test successful');

--- a/server/index.ts
+++ b/server/index.ts
@@ -7,9 +7,10 @@ import { setSiteStorage } from "./site-storage";
 import { logger } from './logger';
 import pinoHttp from 'pino-http';
 import { randomUUID } from 'crypto';
+import { config } from './config';
 
-const BASE_DEV_URL = process.env.BASE_DEV_URL || "http://0.0.0.0:5000/api";
-const BASE_CODEX_URL = process.env.BASE_CODEX_URL || `https://conduit.replit.app/api`;
+const BASE_DEV_URL = config.baseDevUrl;
+const BASE_CODEX_URL = config.baseCodexUrl;
 
 async function init() {
   try {
@@ -72,7 +73,7 @@ app.use((req, res, next) => {
 
 
 (async () => {
-  if (process.env.STORAGE_MODE === 'memory') {
+  if (config.storageMode === 'memory') {
     const { memorySiteStorage } = await import('./memory-storage');
     setSiteStorage(memorySiteStorage);
     logger.info('Using in-memory site storage');
@@ -101,7 +102,7 @@ app.use((req, res, next) => {
   // Other ports are firewalled. Default to 5000 if not specified.
   // this serves both the API and the client.
   // It is the only port that is not firewalled.
-  const port = parseInt(process.env.PORT || '5000', 10);
+  const port = config.port;
   server.listen({
     port,
     host: "0.0.0.0",

--- a/server/logger.ts
+++ b/server/logger.ts
@@ -1,5 +1,6 @@
 import pino from 'pino';
+import { config } from './config';
 
 export const logger = pino({
-  level: process.env.LOG_LEVEL || 'info',
+  level: config.logLevel,
 });

--- a/server/objectStorage.ts
+++ b/server/objectStorage.ts
@@ -3,8 +3,9 @@ import { Response } from "express";
 import { randomUUID } from "crypto";
 import { Readable } from "stream";
 import { logger } from './logger';
+import { config } from './config';
 
-const REPLIT_SIDECAR_ENDPOINT = process.env.REPLIT_SIDECAR_ENDPOINT;
+const REPLIT_SIDECAR_ENDPOINT = config.objectStorage.replitSidecarEndpoint;
 
 class MemoryFile {
   private content?: Buffer;
@@ -92,7 +93,7 @@ export class ObjectStorageService {
 
   // Gets the public object search paths.
   getPublicObjectSearchPaths(): Array<string> {
-    const pathsStr = process.env.PUBLIC_OBJECT_SEARCH_PATHS || "";
+    const pathsStr = config.objectStorage.publicObjectSearchPaths || "";
     const paths = Array.from(
       new Set(
         pathsStr
@@ -112,7 +113,7 @@ export class ObjectStorageService {
 
   // Gets the private object directory.
   getPrivateObjectDir(): string {
-    const dir = process.env.PRIVATE_OBJECT_DIR || "";
+    const dir = config.objectStorage.privateObjectDir || "";
     if (!dir) {
       throw new Error(
         "PRIVATE_OBJECT_DIR not set. Create a bucket in 'Object Storage' " +

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -13,6 +13,7 @@ import { db } from "./db";
 import { sql } from "drizzle-orm";
 import rateLimit from "express-rate-limit";
 import { logger } from './logger';
+import { config } from './config';
 
 export async function registerRoutes(app: Express): Promise<Server> {
   logger.info('Registering routes...');
@@ -22,7 +23,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   logger.info('Google authentication setup complete');
   
   // Test HubSpot connection if API key is available
-  if (process.env.HUBSPOT_API_KEY) {
+  if (config.hubspotApiKey) {
     logger.info('Testing HubSpot API connection...');
     const hubspotConnected = await testHubSpotConnection();
     if (hubspotConnected) {
@@ -80,7 +81,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const lead = await siteStorage.createSiteLead(leadData);
       
       // Send to HubSpot forms asynchronously (don't block the response)
-      if (process.env.HUBSPOT_API_KEY) {
+      if (config.hubspotApiKey) {
         setImmediate(async () => {
           try {
             const hubspotContact: HubSpotContact = {


### PR DESCRIPTION
## Summary
- add `server/config.ts` to parse and validate environment variables
- replace scattered `process.env` access with typed config imports across server modules
- document env vars and validation in README and Codex

## Testing
- `npm test` *(fails: Failed to load url pino in server/logger.ts)*
- `npx vitest run --dir server` *(fails: Failed to load url pino and supertest)*

------
https://chatgpt.com/codex/tasks/task_e_68be1bf3cdb48331bc5c5ff9d3ac036f