### PR TITLE
fix: safeguard logout when session missing

### DIFF
--- a/server/google-auth.ts
+++ b/server/google-auth.ts
@@ -206,19 +206,30 @@ export async function setupAuth(app: Express) {
     }
   });
 
-  // Logout endpoint  
+  // Logout endpoint
   app.post('/api/logout', (req, res) => {
     req.logout((err) => {
       if (err) {
         logger.error('Logout error:', err);
         return res.status(500).json({ error: 'Logout failed' });
       }
+      const hasCookie = req.headers.cookie?.includes('connect.sid=');
+
+      if (!req.session) {
+        if (hasCookie) {
+          res.clearCookie('connect.sid');
+        }
+        return res.json({ message: 'Logged out successfully' });
+      }
+
       req.session.destroy((err) => {
         if (err) {
           logger.error('Session destroy error:', err);
           return res.status(500).json({ error: 'Session cleanup failed' });
         }
-        res.clearCookie('connect.sid');
+        if (hasCookie) {
+          res.clearCookie('connect.sid');
+        }
         res.json({ message: 'Logged out successfully' });
       });
     });


### PR DESCRIPTION
## Summary
- guard logout when session or cookie not present

## Testing
- `npm test` *(fails: Error: Failed to load url supertest...)*
- `npm run check` *(fails: server/objectStorage.ts(12,88): error TS1128: Declaration or statement expected.)*

------
https://chatgpt.com/codex/tasks/task_e_68bf4e92ba2883318f72207e034829de