### PR TITLE
Avoid logout when no session

### DIFF
--- a/server/google-auth.ts
+++ b/server/google-auth.ts
@@ -208,12 +208,17 @@ export async function setupAuth(app: Express) {
 
   // Logout endpoint
   app.post('/api/logout', (req, res) => {
+    const hasCookie = req.headers.cookie?.includes('connect.sid=');
+
+    if (!req.session && !hasCookie) {
+      return res.json({ message: 'Logged out successfully' });
+    }
+
     req.logout((err) => {
       if (err) {
         logger.error('Logout error:', err);
         return res.status(500).json({ error: 'Logout failed' });
       }
-      const hasCookie = req.headers.cookie?.includes('connect.sid=');
 
       if (!req.session) {
         if (hasCookie) {


### PR DESCRIPTION
## Summary
- Only attempt logout when session or cookie is present
- Skip session/cookie cleanup when none exists

## Testing
- `npm test` *(fails: Cannot find package 'supertest', cannot connect to database, etc.)*
- `npm run dev:mem` *(fails: [postcss] Cannot read properties of undefined)*
- `curl -i -X POST http://localhost:5000/api/logout` *(returns HTML due to server failure)*

------
https://chatgpt.com/codex/tasks/task_e_68bf5099a3488331abe816ad43ed2148