### PR TITLE
feat: show manager account status

### DIFF
--- a/shared/site-schema.ts
+++ b/shared/site-schema.ts
@@ -358,6 +358,7 @@ export type InsertSiteLead = z.infer<typeof insertSiteLeadSchema>;
 export type SiteAnalytics = typeof siteAnalytics.$inferSelect;
 export type InsertSiteAnalytics = z.infer<typeof insertSiteAnalyticsSchema>;
 export type SiteManager = typeof siteManagers.$inferSelect;
+export type SiteManagerWithAccount = SiteManager & { hasAccount: boolean };
 export type InsertSiteManager = z.infer<typeof insertSiteManagerSchema>;
 export type LegalDisclaimer = typeof legalDisclaimers.$inferSelect;
 export type InsertLegalDisclaimer = z.infer<typeof insertLegalDisclaimerSchema>;


### PR DESCRIPTION
## Summary
- join site managers with users to flag which managers have accounts
- add `SiteManagerWithAccount` type for response typing

## Testing
- `npm run check` (fails: Property 'createdById' does not exist ...)
- `npm test` (fails: Failed to load url supertest, pino, etc.)

------
https://chatgpt.com/codex/tasks/task_e_68bf6b9966ac8331a520d6b799ff37aa