### PR TITLE
feat: show invited badge for unmatched managers

### DIFF
--- a/client/src/pages/site-admin.tsx
+++ b/client/src/pages/site-admin.tsx
@@ -2495,10 +2495,19 @@ export function SiteAdmin(props: SiteAdminProps) {
                                 />
                               )}
                               <div>
-                                <p className="font-medium">
-                                  {managerUser?.firstName} {managerUser?.lastName}
+                                <p className="font-medium flex items-center gap-2">
+                                  {managerUser
+                                    ? `${managerUser.firstName} ${managerUser.lastName}`
+                                    : manager.userEmail}
+                                  {!managerUser && (
+                                    <Badge variant="outline" className="text-xs">
+                                      Invited
+                                    </Badge>
+                                  )}
                                 </p>
-                                <p className="text-sm text-slate-400">{manager.userEmail}</p>
+                                {managerUser && (
+                                  <p className="text-sm text-slate-400">{manager.userEmail}</p>
+                                )}
                                 <p className="text-xs text-slate-500">
                                   Added {manager.createdAt ? new Date(manager.createdAt).toLocaleDateString() : 'Unknown date'}
                                 </p>


### PR DESCRIPTION
## Summary
- mark site managers without user accounts as "Invited"
- hide invite badge when a user record is later found

## Testing
- `npm test` *(fails: Failed to load url pino, supertest, etc)*

------
https://chatgpt.com/codex/tasks/task_e_68bf6dc481fc833183738f3b28353d40