### PR TITLE
refactor slide file path handling

### DIFF
--- a/8o8.md
+++ b/8o8.md
@@ -1,0 +1,4 @@
+# 8o8
+
+- Refactored `getSlideFile` to detect standard `/<bucket>/<object>` paths and Replit-specific `/.private/` paths.
+- Supports both Replit object storage and Google Cloud Storage style paths.


### PR DESCRIPTION
## Summary
- detect both Replit and bucket/object path formats in `getSlideFile`
- add documentation about supported slide paths

## Testing
- `npm test` *(fails: Failed to load url @replit/object-storage and other module resolution errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c05df9e20c83319a2897e3b4e11303