### PR TITLE
Prefix non-http slide images

### DIFF
--- a/8o8.md
+++ b/8o8.md
@@ -2,3 +2,4 @@
 
 - Refactored `getSlideFile` to detect standard `/<bucket>/<object>` paths and Replit-specific `/.private/` paths.
 - Supports both Replit object storage and Google Cloud Storage style paths.
+- Updated presentation viewer to prefix `/slide-images` for non-HTTP image URLs, ensuring Replit paths continue to work without a special check.

--- a/client/src/components/presentation-viewer.tsx
+++ b/client/src/components/presentation-viewer.tsx
@@ -274,9 +274,9 @@ export function PresentationViewer({ siteId, siteType, onOpenLearnMore }: Presen
     .sort((a, b) => parseInt(a.slideOrder || "0") - parseInt(b.slideOrder || "0"))
     .map(slide => {
       console.log('Processing slide:', slide.title, 'imageUrl:', slide.imageUrl);
-      // For object storage paths, use the slide-images endpoint
+      // For non-HTTP paths, use the slide-images endpoint
       let imageUrl = slide.imageUrl;
-      if (imageUrl && imageUrl.startsWith('/replit-objstore-')) {
+      if (imageUrl && !imageUrl.startsWith('http')) {
         imageUrl = `/slide-images${imageUrl}`;
       }
       
@@ -345,7 +345,7 @@ export function PresentationViewer({ siteId, siteType, onOpenLearnMore }: Presen
             } else {
               // Handle image slides - use imageUrl and apply same processing as site slides
               let imageUrl = slide.imageUrl;
-              if (imageUrl && imageUrl.startsWith('/replit-objstore-')) {
+              if (imageUrl && !imageUrl.startsWith('http')) {
                 imageUrl = `/slide-images${imageUrl}`;
               }
               


### PR DESCRIPTION
## Summary
- Prefix non-http presentation slide images with `/slide-images`
- Document slide image URL prefixing

## Testing
- `npm test` *(fails: Failed Suites 4)*
- `npm run check` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c0606966c883318c8476a4ad025c1c