### PR TITLE
feat: add in-memory development script

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ variables like `DATABASE_URL`, `SESSION_SECRET`, and others listed below.
 
 - **Docker Postgres**: `npm run db:up`, `npm run db:migrate`, `npm run db:seed`, `npm run dev`
   - Spins up a Postgres container and loads seed data from `server/seeds/`.
-- **In-memory**: set `AUTH_DISABLED=true` and `STORAGE_MODE=memory`, then `npm run dev`
-  - Bypasses authentication and uses `server/data/seed.json` for ephemeral data.
+- **In-memory**: `npm run dev:mem`
+  - Starts the server with `AUTH_DISABLED=true` and `STORAGE_MODE=memory` for ephemeral data.
 
 ### Environment variables
 
@@ -102,7 +102,9 @@ This allows each environment to ship branded decks without modifying source code
 
 Setting `STORAGE_MODE=memory` launches the API using JSON files loaded into RAM
 instead of Postgres. Seed data lives in `server/data/seed.json`. Because changes
-aren't persisted, restart the server to reset to the contents of that file.
+aren't persisted, restart the server to reset to the contents of that file. Use
+`npm run dev:mem` to start the server with these settings and authentication
+disabled.
 
 ## Self-Contained Tools
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "scripts": {
     "dev": "cross-env NODE_ENV=development tsx server/index.ts",
+    "dev:mem": "cross-env NODE_ENV=development STORAGE_MODE=memory AUTH_DISABLED=true tsx server/index.ts",
     "dev:explorer": "cross-env NODE_ENV=development tsx server/explorer.ts",
     "dev:card": "cross-env NODE_ENV=development tsx server/card-builder.ts",
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",


### PR DESCRIPTION
## Summary
- add `dev:mem` script to launch server with in-memory storage and auth disabled
- document `dev:mem` usage for local development

## Testing
- `npm test` *(fails: Failed to load modules and invalid URL errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c0bf28e734833190834841a8db296b