### PR TITLE
Dynamically import route module based on storage mode

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -1,5 +1,4 @@
 import express, { type Request, Response, NextFunction } from "express";
-import { registerRoutes } from "./routes";
 import { setupVite, serveStatic } from "./vite";
 import { setSiteStorage } from "./site-storage";
 import { logger } from './logger';
@@ -104,6 +103,10 @@ app.use((req, res, next) => {
     logger.info('Using in-memory site storage');
   }
 
+  const { registerRoutes } =
+    config.storageMode === 'memory'
+      ? await import('./memory-routes')
+      : await import('./routes');
   const server = await registerRoutes(app);
 
   app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {


### PR DESCRIPTION
## Summary
- Load memory or default routes via dynamic import depending on `STORAGE_MODE`.
- Keep downstream logic intact by assigning the resulting server instance.

## Testing
- `npm test` *(fails: Failed to load modules and invalid URL errors)*
- `npm run check` *(fails: TypeScript compilation errors in site-storage and others)*

------
https://chatgpt.com/codex/tasks/task_e_68c0bfe19e788331bfce2d248603e8cd