### PR TITLE
feat: add memory routes with health endpoint

### DIFF
--- a/server/memory-routes.ts
+++ b/server/memory-routes.ts
@@ -1,0 +1,33 @@
+import type { Express } from "express";
+import { createServer, type Server } from "http";
+
+export function registerMemoryRoutes(app: Express): Server {
+  // Basic health check endpoint
+  app.get("/api/health", (_req, res) => {
+    res.json({ ok: true });
+  });
+
+  // Root landing page or delegate to Vite in development
+  app.get("/", (_req, res, next) => {
+    if (app.get("env") === "development") {
+      // Vite middleware will handle this in development
+      return next();
+    }
+
+    res.type("html").send(`<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Mining Syndicate</title>
+  </head>
+  <body>
+    <h1>Mining Syndicate API</h1>
+  </body>
+</html>`);
+  });
+
+  return createServer(app);
+}
+
+// Export alias for compatibility with existing imports
+export { registerMemoryRoutes as registerRoutes };


### PR DESCRIPTION
## Summary
- add in-memory route registration with health check
- serve simple HTML or defer to Vite for root requests

## Testing
- `npm test` *(fails: Error: Failed to load url supertest, TypeError: Invalid URL, expected 'MemoryStorage')*
- `npm run check` *(fails: TS2345, TS2551, TS2339)*

------
https://chatgpt.com/codex/tasks/task_e_68c0c13ab39c83319f6a6c00983fea83