### PR TITLE
feat: allow runtime storage replacement

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -582,7 +582,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   });
 
   // Register multi-site routes
-  registerSiteRoutes(app, storage);
+  registerSiteRoutes(app);
   logger.info('Site management routes registered');
 
   const httpServer = createServer(app);

--- a/server/site-routes/index.ts
+++ b/server/site-routes/index.ts
@@ -16,7 +16,7 @@ import { isAuthenticated } from "../google-auth";
 import { z } from "zod";
 import { registerSiteCreateRoutes } from "./site-create";
 import { logger } from '../logger';
-export function registerSiteRoutes(app: Express, storage?: any) {
+export function registerSiteRoutes(app: Express) {
   registerSiteCreateRoutes(app);
 
   // Get site by siteId (no access control for basic site info - admin panel handles its own access control)

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -653,4 +653,8 @@ export class DatabaseStorage implements IStorage {
   }
 }
 
-export const storage = new DatabaseStorage();
+export let storage: IStorage = new DatabaseStorage();
+
+export function setStorage(storageImpl: IStorage) {
+  storage = storageImpl;
+}


### PR DESCRIPTION
## Summary
- make storage export mutable and add runtime `setStorage`
- remove `storage` parameter from site routes and register using module import

## Testing
- `npm run check` *(fails: Argument type errors in site-storage etc.)*
- `npm test` *(fails: missing modules and invalid URL configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68c0c4f60c408331bc6980c7586c671c