### PR TITLE
feat: enable memory core storage

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -1,6 +1,7 @@
 import express, { type Request, Response, NextFunction } from "express";
 import { setupVite, serveStatic } from "./vite";
 import { setSiteStorage } from "./site-storage";
+import { setStorage } from "./storage";
 import { logger } from './logger';
 import pinoHttp from 'pino-http';
 import { randomUUID } from 'crypto';
@@ -101,6 +102,10 @@ app.use((req, res, next) => {
     const { memorySiteStorage } = await import('./memory-storage');
     setSiteStorage(memorySiteStorage);
     logger.info('Using in-memory site storage');
+
+    const { memoryStorage } = await import('./memory-core-storage');
+    setStorage(memoryStorage);
+    logger.info('Memory storage active');
   }
 
   const { registerRoutes } =


### PR DESCRIPTION
## Summary
- dynamically load memory core storage when using memory storage mode
- wire up setStorage to use in-memory implementation and log status

## Testing
- `npm test` *(fails: Failed to load url supertest; Invalid URL; etc)*

------
https://chatgpt.com/codex/tasks/task_e_68c0c5e9453483319730c757f1cf7026