### PR TITLE
Skip DB check in memory health endpoint

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -36,8 +36,12 @@ export async function registerRoutes(app: Express): Promise<Server> {
     logger.info('HubSpot API key not found - lead sync disabled');
   }
 
-  // Basic health check endpoint to verify DB connectivity
+  // Basic health check endpoint
   app.get("/api/health", async (_req, res) => {
+    if (config.storageMode === "memory") {
+      return res.json({ ok: true });
+    }
+
     try {
       await db.execute(sql`select 1`);
       res.json({ ok: true });


### PR DESCRIPTION
## Summary
- Avoid database ping in `/api/health` when storage mode is memory

## Testing
- `npm test` *(fails: Invalid URL, missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68c0c79f77088331957e63d52c3d192c