### PR TITLE
feat: stub db for memory mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,8 @@ Setting `STORAGE_MODE=memory` launches the API using JSON files loaded into RAM
 instead of Postgres. Seed data lives in `server/data/seed.json`. Because changes
 aren't persisted, restart the server to reset to the contents of that file. Use
 `npm run dev:mem` to start the server with these settings and authentication
-disabled.
+disabled. In this mode, the database layer exports a stub with no-op methods for
+development and testing only; do not rely on it in production.
 
 ## Self-Contained Tools
 


### PR DESCRIPTION
## Summary
- export in-memory stub `db` and skip pool creation when `STORAGE_MODE=memory`
- document that the stub database is only for local development/testing

## Testing
- `npm test` *(fails: Failed to load url pino; expected 'Storage' to be 'MemoryStorage')*
- `npm run check` *(fails: TS2339 Property 'incrementBlogPostViewCount' does not exist on type 'ISiteStorage')*

------
https://chatgpt.com/codex/tasks/task_e_68c0c86c96c08331a8b65e698a024f26