### PR TITLE
feat: add in-memory storage for collective features

### DIFF
--- a/server/data/seed.json
+++ b/server/data/seed.json
@@ -17,5 +17,18 @@
   "siteSlides": [],
   "globalSlides": [],
   "siteSections": [],
-  "siteMemberships": []
+  "siteMemberships": [],
+  "collectiveTasks": [],
+  "taskAssignments": [],
+  "collectiveMessages": [],
+  "collectiveBlogPosts": [],
+  "users": [
+    {
+      "id": "demo-user",
+      "firstName": "Demo",
+      "lastName": "User",
+      "email": "demo@example.com",
+      "profilePicture": null
+    }
+  ]
 }

--- a/server/site-storage.ts
+++ b/server/site-storage.ts
@@ -69,9 +69,31 @@ export interface ISiteStorage {
   createSiteMembership(membershipData: any): Promise<any>;
   updateSiteMembership(siteId: string, userId: string, updates: any): Promise<any>;
   deleteSiteMembership(siteId: string, userId: string): Promise<boolean>;
-  
+
   // Access control
   checkSiteAccess(siteId: string, userEmail: string, isAdmin: boolean): Promise<boolean>;
+
+  // Collective Messages Methods
+  getCollectiveMessages(siteId: string, options: { limit: number; offset: number }): Promise<any[]>;
+  createCollectiveMessage(messageData: any): Promise<any>;
+  getCollectiveMessageWithSender(messageId: string): Promise<any>;
+
+  // Collective Blog Posts Methods
+  getCollectiveBlogPosts(siteId: string, options: { status?: string; userRole?: string; limit?: number; offset?: number }): Promise<any[]>;
+  getCollectiveBlogPostById(postId: string): Promise<any>;
+  createCollectiveBlogPost(postData: any): Promise<any>;
+  updateCollectiveBlogPost(postId: string, updates: any): Promise<any>;
+  deleteCollectiveBlogPost(postId: string): Promise<void>;
+  incrementBlogPostViewCount(postId: string): Promise<void>;
+
+  // Collective Tasks Methods
+  getCollectiveTasks(siteId: string, options: { status?: string; limit?: number; offset?: number }): Promise<any[]>;
+  getCollectiveTaskById(taskId: string): Promise<any>;
+  createCollectiveTask(taskData: any): Promise<any>;
+  updateCollectiveTask(taskId: string, updates: any): Promise<any>;
+  deleteCollectiveTask(taskId: string): Promise<void>;
+  getUserTasks(siteId: string, userId: string): Promise<any[]>;
+  assignTaskToUser(taskId: string, userId: string, assignedById: string): Promise<any>;
 }
 
 export class DatabaseSiteStorage implements ISiteStorage {


### PR DESCRIPTION
## Summary
- extend ISiteStorage and memory storage with collective messages, blog posts, and tasks APIs
- seed in-memory storage with demo user and arrays for new features

## Testing
- `npm test` *(fails: Failed to load url supertest, pino dependencies and others)*

------
https://chatgpt.com/codex/tasks/task_e_68c0ccca99888331953411a8be0ae049