### PR TITLE
feat: add optional memory persistence

### DIFF
--- a/server/memory-core-storage.ts
+++ b/server/memory-core-storage.ts
@@ -76,11 +76,22 @@ function loadSeed(): SeedData {
   }
 }
 
+function saveSeed(data: SeedData) {
+  const seedPath = path.join(__dirname, "data", "core-seed.json");
+  fs.writeFileSync(seedPath, JSON.stringify(data, null, 2));
+}
+
 export class MemoryStorage implements IStorage {
   private data: SeedData;
 
   constructor(seedData?: SeedData) {
     this.data = seedData ?? loadSeed();
+  }
+
+  persist(): void {
+    if (process.env.MEMORY_PERSIST === "true") {
+      saveSeed(this.data);
+    }
   }
 
   async getUser(id: string): Promise<User | undefined> {
@@ -589,3 +600,10 @@ export class MemoryStorage implements IStorage {
 }
 
 export const memoryStorage = new MemoryStorage();
+
+if (process.env.MEMORY_PERSIST === "true") {
+  const handler = () => memoryStorage.persist();
+  process.on("beforeExit", handler);
+  process.on("SIGINT", handler);
+  process.on("SIGTERM", handler);
+}

--- a/server/memory-storage.ts
+++ b/server/memory-storage.ts
@@ -67,11 +67,22 @@ function loadSeed(): SeedData {
   }
 }
 
+function saveSeed(data: SeedData) {
+  const seedPath = path.join(__dirname, "data", "seed.json");
+  fs.writeFileSync(seedPath, JSON.stringify(data, null, 2));
+}
+
 export class MemorySiteStorage implements ISiteStorage {
   private data: SeedData;
 
   constructor() {
     this.data = loadSeed();
+  }
+
+  persist(): void {
+    if (process.env.MEMORY_PERSIST === "true") {
+      saveSeed(this.data);
+    }
   }
 
   // Site operations
@@ -739,4 +750,11 @@ export class MemorySiteStorage implements ISiteStorage {
 }
 
 export const memorySiteStorage = new MemorySiteStorage();
+
+if (process.env.MEMORY_PERSIST === "true") {
+  const handler = () => memorySiteStorage.persist();
+  process.on("beforeExit", handler);
+  process.on("SIGINT", handler);
+  process.on("SIGTERM", handler);
+}
 


### PR DESCRIPTION
## Summary
- allow memory storage to persist data to disk via new `saveSeed()` helper
- expose `persist()` and register exit hooks for in-memory core and site storage
- gate persistence with `MEMORY_PERSIST=true`

## Testing
- `npm test` *(fails: Failed to load url supertest; pino module errors; Cannot read properties of undefined (reading 'dispose'))*

------
https://chatgpt.com/codex/tasks/task_e_68c0cf03c7ac8331a2d45000dd73fdac