### PR TITLE
feat: add filesystem object storage fallback

### DIFF
--- a/server/__tests__/objectStorage.test.ts
+++ b/server/__tests__/objectStorage.test.ts
@@ -1,9 +1,14 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { Storage } from '@google-cloud/storage';
 
-process.env.DATABASE_URL = process.env.DATABASE_URL || 'postgres://postgres:postgres@localhost:5432/postgres';
+process.env.DATABASE_URL =
+  process.env.DATABASE_URL || 'postgres://postgres:postgres@localhost:5432/postgres';
+process.env.AUTH_DISABLED = 'true';
 
 afterEach(() => {
+  delete process.env.REPLIT_SIDECAR_ENDPOINT;
+  delete process.env.PRIVATE_OBJECT_DIR;
+  delete process.env.STORAGE_MODE;
   vi.resetModules();
 });
 
@@ -15,12 +20,19 @@ describe('objectStorage client selection', () => {
   });
 
   it('uses memory storage when REPLIT_SIDECAR_ENDPOINT is absent', async () => {
-    delete process.env.REPLIT_SIDECAR_ENDPOINT;
     process.env.PRIVATE_OBJECT_DIR = '/bucket';
     const mod = await import('../objectStorage');
     expect(mod.objectStorageClient.constructor.name).toBe('MemoryStorage');
     const service = new mod.ObjectStorageService();
     const url = await service.getSlideUploadURL();
     expect(url).toMatch(/\/bucket\/slides\//);
+  });
+
+  it('uses memory storage when STORAGE_MODE is memory', async () => {
+    process.env.REPLIT_SIDECAR_ENDPOINT = 'http://127.0.0.1:1106';
+    process.env.STORAGE_MODE = 'memory';
+    process.env.PRIVATE_OBJECT_DIR = '/bucket';
+    const mod = await import('../objectStorage');
+    expect(mod.objectStorageClient.constructor.name).toBe('MemoryStorage');
   });
 });


### PR DESCRIPTION
## Summary
- add local filesystem-backed object storage when Replit sidecar is absent or in memory mode
- choose storage implementation at runtime based on env and config
- test object storage client selection for memory and remote modes

## Testing
- `npx vitest run --dir server server/__tests__/objectStorage.test.ts`
- `npm run pre-commit`
- `npm run check` *(fails: TS errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c0d0fe827483319f4fa971a8d3caaf