### PR TITLE
feat: skip init fetch in memory mode

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -12,6 +12,11 @@ const BASE_DEV_URL = config.baseDevUrl;
 const BASE_CODEX_URL = config.baseCodexUrl;
 
 async function init() {
+  if (config.storageMode === 'memory') {
+    logger.info('In-memory mode active; skipping init');
+    return;
+  }
+
   try {
     const response = await fetch(`${BASE_DEV_URL}/visible-slides`);
     if (!response.ok) {
@@ -140,6 +145,8 @@ app.use((req, res, next) => {
     reusePort: true,
   }, async () => {
     logger.info(`serving on port ${port}`);
-    await init();
+    if (config.storageMode !== 'memory') {
+      await init();
+    }
   });
 })();


### PR DESCRIPTION
## Summary
- bypass init API calls when using in-memory storage
- call init only when storage uses external persistence

## Testing
- `npm test` *(fails: Failed to load url supertest/pino, other test errors)*
- `npm run check` *(fails: TypeScript compile errors)*
- `npm run pre-commit`

------
https://chatgpt.com/codex/tasks/task_e_68c0d5af5e7083318e363615b588d2d7