### PR TITLE
feat: disable auth by default in memory mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,8 +7,8 @@ GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 GOOGLE_OAUTH_CALLBACK_URL=http://localhost:5000/api/auth/google/callback
 
-# Development authentication bypass
-AUTH_DISABLED=false
+# Development authentication bypass (defaults to true when STORAGE_MODE=memory)
+AUTH_DISABLED=
 
 # Database
 # Set `DATABASE_URL` to your primary Postgres instance (e.g., `postgres://user:pass@localhost:5432/db`).

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ variables like `DATABASE_URL`, `SESSION_SECRET`, and others listed below.
 - **Docker Postgres**: `npm run db:up`, `npm run db:migrate`, `npm run db:seed`, `npm run dev`
   - Spins up a Postgres container and loads seed data from `server/seeds/`.
 - **In-memory**: `npm run dev:mem`
-  - Starts the server with `AUTH_DISABLED=true` and `STORAGE_MODE=memory` for ephemeral data.
+  - Starts the server with `STORAGE_MODE=memory`; authentication is disabled by default.
 
 ### Environment variables
 
@@ -50,7 +50,7 @@ Environment configuration is managed through Replit's Secrets manager. For local
 | `TEST_DATABASE_URL` | Overrides `DATABASE_URL` during tests for a separate Postgres database. |
 | `SESSION_SECRET` | Secret used to sign Express session cookies. |
 | `HUBSPOT_API_KEY` | Token for submitting forms to HubSpot. |
-| `AUTH_DISABLED` | Set to `true` to bypass authentication with a mock admin user. |
+| `AUTH_DISABLED` | Set to `true` to bypass authentication with a mock admin user. Defaults to `true` when `STORAGE_MODE=memory`. |
 | `PORT` | Port for the combined Express and Vite servers (defaults to `5000`). |
 | `BASE_DEV_URL` | Local API base URL used during initialization. |
 | `BASE_CODEX_URL` | Fallback Codex API endpoint when the local API is unavailable. |
@@ -103,8 +103,9 @@ This allows each environment to ship branded decks without modifying source code
 Setting `STORAGE_MODE=memory` launches the API using JSON files loaded into RAM
 instead of Postgres. Seed data lives in `server/data/seed.json`. Because changes
 aren't persisted, restart the server to reset to the contents of that file. Use
-`npm run dev:mem` to start the server with these settings and authentication
-disabled. In this mode, the database layer exports a stub with no-op methods for
+`npm run dev:mem` to start the server with these settings. Authentication is
+disabled by default in this mode but can be enabled by setting `AUTH_DISABLED=false`.
+In this mode, the database layer exports a stub with no-op methods for
 development and testing only; do not rely on it in production.
 
 ## Self-Contained Tools

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -37,7 +37,7 @@ This guide covers setting up the project locally, running tests, and establishin
    ```bash
    cp .env.example .env
    ```
-2. Set `AUTH_DISABLED=true` in `.env` to bypass OAuth.
+2. Set `AUTH_DISABLED=true` in `.env` to bypass OAuth. This is the default when `STORAGE_MODE=memory`.
 3. Start the local Postgres service.
    ```bash
    npm run db:up

--- a/server/config.ts
+++ b/server/config.ts
@@ -28,7 +28,10 @@ const envSchema = z.object({
 
 const env = envSchema.parse(process.env);
 
-const authDisabled = env.AUTH_DISABLED === 'true';
+const authDisabled =
+  env.AUTH_DISABLED !== undefined
+    ? env.AUTH_DISABLED === 'true'
+    : env.STORAGE_MODE === 'memory';
 
 const databaseUrl = env.NODE_ENV === 'test'
   ? env.TEST_DATABASE_URL ?? env.DATABASE_URL


### PR DESCRIPTION
## Summary
- default `authDisabled` to true when running in memory storage unless `AUTH_DISABLED` is set
- document that memory mode disables auth by default and how to re-enable it
- clarify sample env and onboarding instructions

## Testing
- `npm test` *(fails: Failed to load url supertest and other modules)*

------
https://chatgpt.com/codex/tasks/task_e_68c0d68f073c83318c44bfae27a650bf