### PR TITLE
Add configurable default admin email

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,8 @@ PORT=5000
 BASE_DEV_URL=http://0.0.0.0:5000/api
 BASE_CODEX_URL=https://conduit.replit.app/api
 STORAGE_MODE=memory
+# Default administrator email
+DEFAULT_ADMIN_EMAIL=bnelson523@gmail.com
 
 # Object storage
 # Leave REPLIT_SIDECAR_ENDPOINT unset to use in-memory storage locally

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Environment configuration is managed through Replit's Secrets manager. For local
 | `SESSION_SECRET` | Secret used to sign Express session cookies. |
 | `HUBSPOT_API_KEY` | Token for submitting forms to HubSpot. |
 | `AUTH_DISABLED` | Set to `true` to bypass authentication with a mock admin user. Defaults to `true` when `STORAGE_MODE=memory`. |
+| `DEFAULT_ADMIN_EMAIL` | Email address granted admin rights and initial access. |
 | `PORT` | Port for the combined Express and Vite servers (defaults to `5000`). |
 | `BASE_DEV_URL` | Local API base URL used during initialization. |
 | `BASE_CODEX_URL` | Fallback Codex API endpoint when the local API is unavailable. |

--- a/client/src/components/user-management.tsx
+++ b/client/src/components/user-management.tsx
@@ -10,6 +10,7 @@ import { Input } from '@/components/ui/input';
 import { Shield, UserCheck, User, Edit3, Plus, Mail, Trash2, UserPlus } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
 import { apiRequest } from '@/lib/queryClient';
+import { config } from '../../../server/config';
 
 interface UserType {
   id: string;
@@ -454,7 +455,7 @@ export function UserManagement() {
                       </div>
                     </div>
                   </div>
-                  {entry.email !== "bnelson523@gmail.com" && (
+                  {entry.email !== config.defaultAdminEmail && (
                     <Button
                       variant="outline"
                       size="sm"

--- a/server/config.ts
+++ b/server/config.ts
@@ -23,6 +23,7 @@ const envSchema = z.object({
   REPLIT_SIDECAR_ENDPOINT: z.string().optional(),
   PUBLIC_OBJECT_SEARCH_PATHS: z.string().optional(),
   PRIVATE_OBJECT_DIR: z.string().optional(),
+  DEFAULT_ADMIN_EMAIL: z.string().default('bnelson523@gmail.com'),
   LOG_LEVEL: z.string().default('info'),
 });
 
@@ -63,6 +64,7 @@ const config = {
   storageMode: env.STORAGE_MODE,
   sessionSecret: env.SESSION_SECRET,
   databaseUrl: env.STORAGE_MODE === 'memory' ? undefined : databaseUrl, // Database is optional in memory mode
+  defaultAdminEmail: env.DEFAULT_ADMIN_EMAIL,
   replit: {
     domains: (env.REPLIT_DOMAINS ?? env.REPLIT_DEV_DOMAIN ?? 'conduit.replit.app')
       .split(',')

--- a/server/memory-core-storage.ts
+++ b/server/memory-core-storage.ts
@@ -31,6 +31,7 @@ import {
 } from "@shared/schema";
 import { type SiteLead, type Site } from "@shared/site-schema";
 import type { IStorage } from "./storage";
+import { config } from "./config";
 
 interface SeedData {
   users: User[];
@@ -108,7 +109,7 @@ export class MemoryStorage implements IStorage {
 
   async createUser(user: InsertUser & { isAdmin?: boolean }): Promise<User> {
     const isAdmin =
-      user.email === "bnelson523@gmail.com" || (user as any).isAdmin || false;
+      user.email === config.defaultAdminEmail || (user as any).isAdmin || false;
     const newUser: User = {
       ...(user as any),
       id: randomUUID(),
@@ -129,7 +130,7 @@ export class MemoryStorage implements IStorage {
   }
 
   async checkUserAccess(email: string): Promise<boolean> {
-    if (email === "bnelson523@gmail.com") return true;
+    if (email === config.defaultAdminEmail) return true;
     return this.data.accessList.some((e) => e.email === email);
   }
 
@@ -220,10 +221,10 @@ export class MemoryStorage implements IStorage {
   }
 
   async addToAccessList(email: string, addedBy: string): Promise<AccessListEntry> {
-    if (this.data.accessList.length === 0 && email !== "bnelson523@gmail.com") {
+    if (this.data.accessList.length === 0 && email !== config.defaultAdminEmail) {
       this.data.accessList.push({
         id: randomUUID(),
-        email: "bnelson523@gmail.com",
+        email: config.defaultAdminEmail,
         addedBy: null as any,
         addedAt: new Date(),
       } as AccessListEntry);
@@ -241,7 +242,7 @@ export class MemoryStorage implements IStorage {
   }
 
   async removeFromAccessList(email: string): Promise<void> {
-    if (email === "bnelson523@gmail.com") return;
+    if (email === config.defaultAdminEmail) return;
     this.data.accessList = this.data.accessList.filter((e) => e.email !== email);
   }
 


### PR DESCRIPTION
## Summary
- add `DEFAULT_ADMIN_EMAIL` to env config and expose via `config.defaultAdminEmail`
- replace hard-coded admin email checks with `config.defaultAdminEmail`
- document new `DEFAULT_ADMIN_EMAIL` environment variable

## Testing
- `npm test` *(fails: Failed to load url pino... and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c0d8e32b448331a464ebc4ce54d5e0