### PR TITLE
feat: persist memory storage conditionally

### DIFF
--- a/server/memory-core-storage.ts
+++ b/server/memory-core-storage.ts
@@ -90,6 +90,10 @@ export class MemoryStorage implements IStorage {
   }
 
   persist(): void {
+    this.maybePersist();
+  }
+
+  private maybePersist(): void {
     if (process.env.MEMORY_PERSIST === "true") {
       saveSeed(this.data);
     }
@@ -117,6 +121,7 @@ export class MemoryStorage implements IStorage {
       isAdmin,
     } as User;
     this.data.users.push(newUser);
+    this.maybePersist();
     return newUser;
   }
 
@@ -124,6 +129,7 @@ export class MemoryStorage implements IStorage {
     const existing = this.data.users.find((u) => u.email === (user as any).email);
     if (existing) {
       Object.assign(existing as any, user);
+      this.maybePersist();
       return existing;
     }
     return this.createUser(user as any);
@@ -149,6 +155,7 @@ export class MemoryStorage implements IStorage {
       createdAt: new Date(),
     } as Lead;
     this.data.leads.push(newLead);
+    this.maybePersist();
     return newLead;
   }
 
@@ -187,6 +194,7 @@ export class MemoryStorage implements IStorage {
       } as SlideSetting;
       this.data.slideSettings.push(setting);
     }
+    this.maybePersist();
     return setting;
   }
 
@@ -198,6 +206,7 @@ export class MemoryStorage implements IStorage {
       status: (request as any).status ?? "pending",
     } as AccessRequest;
     this.data.accessRequests.push(entry);
+    this.maybePersist();
     return entry;
   }
 
@@ -213,6 +222,7 @@ export class MemoryStorage implements IStorage {
     const req = this.data.accessRequests.find((r) => r.id === id);
     if (!req) throw new Error("Request not found");
     Object.assign(req as any, { status, reviewedBy, reviewedAt: new Date() });
+    this.maybePersist();
     return req;
   }
 
@@ -228,6 +238,7 @@ export class MemoryStorage implements IStorage {
         addedBy: null as any,
         addedAt: new Date(),
       } as AccessListEntry);
+      this.maybePersist();
     }
     let entry = this.data.accessList.find((e) => e.email === email);
     if (entry) return entry;
@@ -238,12 +249,14 @@ export class MemoryStorage implements IStorage {
       addedAt: new Date(),
     } as AccessListEntry;
     this.data.accessList.push(entry);
+    this.maybePersist();
     return entry;
   }
 
   async removeFromAccessList(email: string): Promise<void> {
     if (email === config.defaultAdminEmail) return;
     this.data.accessList = this.data.accessList.filter((e) => e.email !== email);
+    this.maybePersist();
   }
 
   async getAllUsers(): Promise<User[]> {
@@ -272,6 +285,7 @@ export class MemoryStorage implements IStorage {
       createdAt: new Date(),
     } as FormTemplate;
     this.data.formTemplates.push(newTemplate);
+    this.maybePersist();
     return newTemplate;
   }
 
@@ -282,11 +296,13 @@ export class MemoryStorage implements IStorage {
     const template = this.data.formTemplates.find((t) => t.id === id);
     if (!template) throw new Error("Form template not found");
     Object.assign(template as any, updates, { updatedAt: new Date() });
+    this.maybePersist();
     return template;
   }
 
   async deleteFormTemplate(id: string): Promise<void> {
     this.data.formTemplates = this.data.formTemplates.filter((t) => t.id !== id);
+    this.maybePersist();
   }
 
   // Landing Page Template operations
@@ -309,6 +325,7 @@ export class MemoryStorage implements IStorage {
       createdAt: new Date(),
     } as LandingPageTemplate;
     this.data.landingPageTemplates.push(tpl);
+    this.maybePersist();
     return tpl;
   }
 
@@ -319,6 +336,7 @@ export class MemoryStorage implements IStorage {
     const tpl = this.data.landingPageTemplates.find((t) => t.id === id);
     if (!tpl) throw new Error("Template not found");
     Object.assign(tpl as any, updates, { updatedAt: new Date() });
+    this.maybePersist();
     return tpl;
   }
 
@@ -326,6 +344,7 @@ export class MemoryStorage implements IStorage {
     this.data.landingPageTemplates = this.data.landingPageTemplates.filter(
       (t) => t.id !== id
     );
+    this.maybePersist();
   }
 
   // Site Form Assignment operations
@@ -373,6 +392,7 @@ export class MemoryStorage implements IStorage {
     const assignment = this.data.siteFormAssignments.find((a) => a.id === id);
     if (!assignment) throw new Error("Assignment not found");
     Object.assign(assignment as any, updates, { updatedAt: new Date() });
+    this.maybePersist();
     return assignment;
   }
 
@@ -380,6 +400,7 @@ export class MemoryStorage implements IStorage {
     this.data.siteFormAssignments = this.data.siteFormAssignments.filter(
       (a) => a.id !== id
     );
+    this.maybePersist();
   }
 
   // Site Landing Config operations
@@ -399,6 +420,7 @@ export class MemoryStorage implements IStorage {
       updatedAt: new Date(),
     } as SiteLandingConfig;
     this.data.siteLandingConfigs.push(cfg);
+    this.maybePersist();
     return cfg;
   }
 
@@ -409,6 +431,7 @@ export class MemoryStorage implements IStorage {
     const cfg = this.data.siteLandingConfigs.find((c) => c.siteId === siteId);
     if (!cfg) throw new Error("Site landing config not found");
     Object.assign(cfg as any, updates, { updatedAt: new Date() });
+    this.maybePersist();
     return cfg;
   }
 
@@ -429,6 +452,7 @@ export class MemoryStorage implements IStorage {
       updatedAt: new Date(),
     } as FieldLibrary;
     this.data.fieldLibrary.push(newField);
+    this.maybePersist();
     return newField;
   }
 
@@ -439,11 +463,13 @@ export class MemoryStorage implements IStorage {
     const field = this.data.fieldLibrary.find((f) => f.id === id);
     if (!field) throw new Error("Field not found");
     Object.assign(field as any, updates, { updatedAt: new Date() });
+    this.maybePersist();
     return field;
   }
 
   async deleteFieldLibraryItem(id: string): Promise<void> {
     this.data.fieldLibrary = this.data.fieldLibrary.filter((f) => f.id !== id);
+    this.maybePersist();
   }
 
   // Form Template Fields operations
@@ -470,6 +496,7 @@ export class MemoryStorage implements IStorage {
       updatedAt: new Date(),
     } as FormTemplateField;
     this.data.formTemplateFields.push(newField);
+    this.maybePersist();
     return newField;
   }
 
@@ -480,6 +507,7 @@ export class MemoryStorage implements IStorage {
     const fld = this.data.formTemplateFields.find((f) => f.id === id);
     if (!fld) throw new Error("Form template field not found");
     Object.assign(fld as any, updates, { updatedAt: new Date() });
+    this.maybePersist();
     return fld;
   }
 
@@ -487,6 +515,7 @@ export class MemoryStorage implements IStorage {
     this.data.formTemplateFields = this.data.formTemplateFields.filter(
       (f) => f.id !== id
     );
+    this.maybePersist();
   }
 
   // Site Membership operations
@@ -542,6 +571,7 @@ export class MemoryStorage implements IStorage {
       updatedAt: new Date(),
     } as SiteMembership;
     this.data.siteMemberships.push(mem);
+    this.maybePersist();
     return mem;
   }
 
@@ -552,6 +582,7 @@ export class MemoryStorage implements IStorage {
     const mem = this.data.siteMemberships.find((m) => m.id === id);
     if (!mem) throw new Error("Membership not found");
     Object.assign(mem as any, updates, { updatedAt: new Date() });
+    this.maybePersist();
     return mem;
   }
 
@@ -559,6 +590,7 @@ export class MemoryStorage implements IStorage {
     this.data.siteMemberships = this.data.siteMemberships.filter(
       (m) => m.id !== id
     );
+    this.maybePersist();
   }
 
   // Site Member Profile operations
@@ -580,6 +612,7 @@ export class MemoryStorage implements IStorage {
       updatedAt: new Date(),
     } as SiteMemberProfile;
     this.data.siteMemberProfiles.push(prof);
+    this.maybePersist();
     return prof;
   }
 
@@ -590,6 +623,7 @@ export class MemoryStorage implements IStorage {
     const prof = this.data.siteMemberProfiles.find((p) => p.id === id);
     if (!prof) throw new Error("Profile not found");
     Object.assign(prof as any, updates, { updatedAt: new Date() });
+    this.maybePersist();
     return prof;
   }
 
@@ -597,6 +631,7 @@ export class MemoryStorage implements IStorage {
     this.data.siteMemberProfiles = this.data.siteMemberProfiles.filter(
       (p) => p.id !== id
     );
+    this.maybePersist();
   }
 }
 

--- a/server/memory-storage.ts
+++ b/server/memory-storage.ts
@@ -80,6 +80,10 @@ export class MemorySiteStorage implements ISiteStorage {
   }
 
   persist(): void {
+    this.maybePersist();
+  }
+
+  private maybePersist(): void {
     if (process.env.MEMORY_PERSIST === "true") {
       saveSeed(this.data);
     }
@@ -96,6 +100,7 @@ export class MemorySiteStorage implements ISiteStorage {
       updatedAt: new Date(),
     };
     this.data.sites.push(newSite);
+    this.maybePersist();
     return newSite;
   }
 
@@ -111,11 +116,13 @@ export class MemorySiteStorage implements ISiteStorage {
     const site = await this.getSite(siteId);
     if (!site) throw new Error("Site not found");
     Object.assign(site as any, updates, { updatedAt: new Date() });
+    this.maybePersist();
     return site;
   }
 
   async deleteSite(siteId: string): Promise<void> {
     this.data.sites = this.data.sites.filter((s) => s.siteId !== siteId);
+    this.maybePersist();
   }
 
   async listSites(): Promise<Site[]> {
@@ -131,6 +138,7 @@ export class MemorySiteStorage implements ISiteStorage {
       updatedAt: new Date(),
     };
     this.data.siteLeads.push(newLead);
+    this.maybePersist();
     return newLead;
   }
 
@@ -151,6 +159,7 @@ export class MemorySiteStorage implements ISiteStorage {
     const lead = this.data.siteLeads.find((l) => (l as any).id === leadId);
     if (!lead) throw new Error("Lead not found");
     Object.assign(lead as any, updates, { updatedAt: new Date() });
+    this.maybePersist();
     return lead;
   }
 
@@ -164,6 +173,7 @@ export class MemorySiteStorage implements ISiteStorage {
       createdAt: new Date(),
     };
     this.data.siteAnalytics.push(newEntry);
+    this.maybePersist();
     return newEntry;
   }
 
@@ -187,6 +197,7 @@ export class MemorySiteStorage implements ISiteStorage {
       updatedAt: new Date(),
     } as any;
     this.data.siteManagers.push(manager);
+    this.maybePersist();
     return manager;
   }
 
@@ -194,6 +205,7 @@ export class MemorySiteStorage implements ISiteStorage {
     this.data.siteManagers = this.data.siteManagers.filter(
       (m) => !(m.siteId === siteId && m.userEmail === userEmail)
     );
+    this.maybePersist();
   }
 
   async getSiteManagers(siteId: string): Promise<SiteManager[]> {
@@ -217,6 +229,7 @@ export class MemorySiteStorage implements ISiteStorage {
       updatedAt: new Date(),
     };
     this.data.legalDisclaimers.push(newDisclaimer);
+    this.maybePersist();
     return newDisclaimer;
   }
 
@@ -231,6 +244,7 @@ export class MemorySiteStorage implements ISiteStorage {
     const disclaimer = await this.getLegalDisclaimer(id);
     if (!disclaimer) throw new Error("Disclaimer not found");
     Object.assign(disclaimer as any, updates, { updatedAt: new Date() });
+    this.maybePersist();
     return disclaimer;
   }
 
@@ -238,6 +252,7 @@ export class MemorySiteStorage implements ISiteStorage {
     this.data.legalDisclaimers = this.data.legalDisclaimers.filter(
       (d) => (d as any).id !== id
     );
+    this.maybePersist();
   }
 
   async listLegalDisclaimers(): Promise<LegalDisclaimer[]> {
@@ -266,6 +281,7 @@ export class MemorySiteStorage implements ISiteStorage {
       updatedAt: new Date(),
     } as any;
     this.data.siteDisclaimers.push(attach);
+    this.maybePersist();
     return attach;
   }
 
@@ -276,6 +292,7 @@ export class MemorySiteStorage implements ISiteStorage {
     this.data.siteDisclaimers = this.data.siteDisclaimers.filter(
       (d) => !(d.siteId === siteId && d.disclaimerId === disclaimerId)
     );
+    this.maybePersist();
   }
 
   async getSiteDisclaimers(
@@ -302,6 +319,7 @@ export class MemorySiteStorage implements ISiteStorage {
       updatedAt: new Date(),
     };
     this.data.siteSlides.push(newSlide);
+    this.maybePersist();
     return newSlide;
   }
 
@@ -320,6 +338,7 @@ export class MemorySiteStorage implements ISiteStorage {
     const slide = await this.getSiteSlide(slideId);
     if (!slide) throw new Error("Slide not found");
     Object.assign(slide as any, updates, { updatedAt: new Date() });
+    this.maybePersist();
     return slide;
   }
 
@@ -327,6 +346,7 @@ export class MemorySiteStorage implements ISiteStorage {
     this.data.siteSlides = this.data.siteSlides.filter(
       (s) => (s as any).id !== slideId
     );
+    this.maybePersist();
   }
 
   async reorderSiteSlides(
@@ -338,6 +358,7 @@ export class MemorySiteStorage implements ISiteStorage {
       const slide = slides.find((s) => (s as any).id === id);
       if (slide) (slide as any).slideOrder = slideOrder;
     });
+    this.maybePersist();
   }
 
   // Global slide operations
@@ -357,6 +378,7 @@ export class MemorySiteStorage implements ISiteStorage {
       updatedAt: new Date(),
     };
     this.data.globalSlides.push(slide);
+    this.maybePersist();
     return slide;
   }
 
@@ -368,6 +390,7 @@ export class MemorySiteStorage implements ISiteStorage {
     if (!slide) return null;
     (slide as any).isVisible = isVisible;
     (slide as any).updatedAt = new Date();
+    this.maybePersist();
     return slide;
   }
 
@@ -388,6 +411,7 @@ export class MemorySiteStorage implements ISiteStorage {
       updatedAt: new Date(),
     };
     this.data.siteSections.push(section);
+    this.maybePersist();
     return section;
   }
 
@@ -398,6 +422,7 @@ export class MemorySiteStorage implements ISiteStorage {
     const section = await this.getSiteSection(sectionId);
     if (!section) throw new Error("Section not found");
     Object.assign(section as any, updates, { updatedAt: new Date() });
+    this.maybePersist();
     return section;
   }
 
@@ -405,6 +430,7 @@ export class MemorySiteStorage implements ISiteStorage {
     this.data.siteSections = this.data.siteSections.filter(
       (s) => (s as any).id !== sectionId
     );
+    this.maybePersist();
   }
 
   // Site membership operations (simplified)
@@ -424,6 +450,7 @@ export class MemorySiteStorage implements ISiteStorage {
       updatedAt: new Date(),
     };
     this.data.siteMemberships.push(membership);
+    this.maybePersist();
     return membership;
   }
 
@@ -437,6 +464,7 @@ export class MemorySiteStorage implements ISiteStorage {
     );
     if (!membership) return null;
     Object.assign(membership, updates, { updatedAt: new Date() });
+    this.maybePersist();
     return membership;
   }
 
@@ -445,7 +473,11 @@ export class MemorySiteStorage implements ISiteStorage {
     this.data.siteMemberships = this.data.siteMemberships.filter(
       (m) => !(m.siteId === siteId && m.userId === userId)
     );
-    return this.data.siteMemberships.length < before;
+    const deleted = this.data.siteMemberships.length < before;
+    if (deleted) {
+      this.maybePersist();
+    }
+    return deleted;
   }
 
   // ===== COLLECTIVE MESSAGES METHODS =====
@@ -488,6 +520,7 @@ export class MemorySiteStorage implements ISiteStorage {
       updatedAt: new Date(),
     };
     this.data.collectiveMessages.push(message);
+    this.maybePersist();
     return message;
   }
 
@@ -572,6 +605,7 @@ export class MemorySiteStorage implements ISiteStorage {
       updatedAt: new Date(),
     };
     this.data.collectiveBlogPosts.push(post);
+    this.maybePersist();
     return post;
   }
 
@@ -579,6 +613,7 @@ export class MemorySiteStorage implements ISiteStorage {
     const post = this.data.collectiveBlogPosts.find((p) => p.id === postId);
     if (!post) throw new Error("Post not found");
     Object.assign(post, updates, { updatedAt: new Date() });
+    this.maybePersist();
     return post;
   }
 
@@ -586,12 +621,14 @@ export class MemorySiteStorage implements ISiteStorage {
     this.data.collectiveBlogPosts = this.data.collectiveBlogPosts.filter(
       (p) => p.id !== postId
     );
+    this.maybePersist();
   }
 
   async incrementBlogPostViewCount(postId: string): Promise<void> {
     const post = this.data.collectiveBlogPosts.find((p) => p.id === postId);
     if (post) {
       post.viewCount = (post.viewCount || 0) + 1;
+      this.maybePersist();
     }
   }
 
@@ -654,6 +691,7 @@ export class MemorySiteStorage implements ISiteStorage {
       completedAt: null,
     };
     this.data.collectiveTasks.push(task);
+    this.maybePersist();
     return task;
   }
 
@@ -661,6 +699,7 @@ export class MemorySiteStorage implements ISiteStorage {
     const task = this.data.collectiveTasks.find((t) => t.id === taskId);
     if (!task) throw new Error("Task not found");
     Object.assign(task, updates, { updatedAt: new Date() });
+    this.maybePersist();
     return task;
   }
 
@@ -668,6 +707,7 @@ export class MemorySiteStorage implements ISiteStorage {
     this.data.collectiveTasks = this.data.collectiveTasks.filter(
       (t) => t.id !== taskId
     );
+    this.maybePersist();
   }
 
   async getUserTasks(siteId: string, userId: string): Promise<any[]> {
@@ -715,6 +755,7 @@ export class MemorySiteStorage implements ISiteStorage {
       updatedAt: new Date(),
     };
     this.data.taskAssignments.push(assignment);
+    this.maybePersist();
     return assignment;
   }
 


### PR DESCRIPTION
## Summary
- add maybePersist helper to memory-based storages
- persist in-memory data on create/update/delete when MEMORY_PERSIST is true

## Testing
- `npm test` *(fails: Failed to load url pino)*

------
https://chatgpt.com/codex/tasks/task_e_68c0da525884833186b457e97cf92abe