### PR TITLE
refactor: use slug param in site access control

### DIFF
--- a/server/__tests__/site-manager-access.test.ts
+++ b/server/__tests__/site-manager-access.test.ts
@@ -7,7 +7,7 @@ vi.mock('../logger', () => ({ logger: { info: vi.fn(), error: vi.fn() } }));
 // the user has an account. Once the user signs up (via upsertUser),
 // checkSiteAccess should treat them as a manager and allow site operations.
 
-const SITE_ID = 'access-site';
+const SITE_SLUG = 'access-site';
 const managerEmail = 'precreated-manager@example.com';
 
 let checkSiteAccess: any;
@@ -34,9 +34,9 @@ describe('site manager access after account creation', () => {
     setSiteStorage(new MemorySiteStorage());
 
     const { siteStorage } = await import('../site-storage');
-    await siteStorage.createSite({ siteId: SITE_ID, name: 'Test', siteType: 'standard' } as any);
+    await siteStorage.createSite({ siteId: SITE_SLUG, name: 'Test', siteType: 'standard' } as any);
     // Pre-create a site_managers entry for an email with no user account yet
-    await siteStorage.addSiteManager(SITE_ID, managerEmail);
+    await siteStorage.addSiteManager(SITE_SLUG, managerEmail);
 
     // Import after env setup to avoid config failures
     ({ checkSiteAccess } = await import('../site-access-control'));
@@ -61,9 +61,9 @@ describe('site manager access after account creation', () => {
     });
 
     const { siteStorage } = await import('../site-storage');
-    const site = await siteStorage.getSite(SITE_ID);
+    const site = await siteStorage.getSite(SITE_SLUG);
 
-    const req: any = { params: { slug: SITE_ID }, user };
+    const req: any = { params: { slug: SITE_SLUG }, user };
     const res: any = { status: vi.fn().mockReturnThis(), json: vi.fn() };
     const next = vi.fn();
 

--- a/server/__tests__/site-manager-invite.test.ts
+++ b/server/__tests__/site-manager-invite.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import express from 'express';
 import { request as pwRequest, APIRequestContext } from 'playwright';
 
-const SITE_ID = 'invite-site';
+const SITE_SLUG = 'invite-site';
 const usersData: any[] = [];
 
 vi.mock('../db', () => {
@@ -13,7 +13,7 @@ vi.mock('../db', () => {
         leftJoin: vi.fn().mockReturnThis(),
         where: vi.fn(async () => {
           const { siteStorage } = await import('../site-storage');
-          const managers = await siteStorage.getSiteManagers(SITE_ID);
+          const managers = await siteStorage.getSiteManagers(SITE_SLUG);
           return managers.map((m: any) => ({
             id: m.id,
             siteId: m.siteId,
@@ -75,7 +75,7 @@ describe('site manager invites', () => {
     context = await pwRequest.newContext({ baseURL: started.baseURL });
 
     const { siteStorage } = await import('../site-storage');
-    await siteStorage.createSite({ siteId: SITE_ID, name: 'Test', siteType: 'standard' } as any);
+    await siteStorage.createSite({ siteId: SITE_SLUG, name: 'Test', siteType: 'standard' } as any);
   });
 
   afterEach(async () => {
@@ -90,12 +90,12 @@ describe('site manager invites', () => {
 
   it('reflects account existence in manager listing', async () => {
     const inviteEmail = 'invitee@example.com';
-    const res = await context.post(`/api/sites/${SITE_ID}/managers`, {
+    const res = await context.post(`/api/sites/${SITE_SLUG}/managers`, {
       data: { userEmail: inviteEmail },
     });
     expect(res.status()).toBe(200);
 
-    let getRes = await context.get(`/api/sites/${SITE_ID}/managers`);
+    let getRes = await context.get(`/api/sites/${SITE_SLUG}/managers`);
     expect(getRes.status()).toBe(200);
     let managers = await getRes.json();
     expect(managers[0]).toMatchObject({ userEmail: inviteEmail, hasAccount: false });
@@ -103,7 +103,7 @@ describe('site manager invites', () => {
     const { storage } = await import('../storage');
     await storage.createUser({ email: inviteEmail, firstName: 'A', lastName: 'B' });
 
-    getRes = await context.get(`/api/sites/${SITE_ID}/managers`);
+    getRes = await context.get(`/api/sites/${SITE_SLUG}/managers`);
     managers = await getRes.json();
     expect(managers[0]).toMatchObject({ userEmail: inviteEmail, hasAccount: true });
   });

--- a/server/site-access-control.ts
+++ b/server/site-access-control.ts
@@ -22,7 +22,7 @@ declare global {
  */
 export const checkSiteAccess = async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const { slug } = req.params;
+    const slug = req.params.slug;
     const user = req.user as any;
 
     if (!user) {
@@ -45,7 +45,7 @@ export const checkSiteAccess = async (req: Request, res: Response, next: NextFun
 
     // Global admins have access to all sites, no need to check site manager status
     if (isAdmin) {
-      logger.info(`Global admin ${user.email} granted access to site ${slug}`); // Changed from siteId to slug
+      logger.info(`Global admin ${user.email} granted access to site ${slug}`);
       // Add access info to request object
       req.siteAccess = {
         siteId: site.id,
@@ -62,7 +62,7 @@ export const checkSiteAccess = async (req: Request, res: Response, next: NextFun
     logger.info(`Site manager check for ${slug}: user=${user.email}, isSiteManager=${isSiteManager}`);
 
     if (isSiteManager) {
-      logger.info(`Site manager ${user.email} granted access to site ${slug}`); // Changed from siteId to slug
+      logger.info(`Site manager ${user.email} granted access to site ${slug}`);
       // Add access info to request object
       req.siteAccess = {
         siteId: site.id,


### PR DESCRIPTION
## Summary
- read `req.params.slug` in site access middleware
- align site manager tests with slug terminology

## Testing
- `npm test` *(fails: Failed to load url pino and supertest)*

------
https://chatgpt.com/codex/tasks/task_e_68c338cdf3c88331bf8c68fffb6daa70